### PR TITLE
fix test on Doctrine EntityManagerInterface

### DIFF
--- a/src/Embeddings/VectorStores/Doctrine/DoctrineVectorStore.php
+++ b/src/Embeddings/VectorStores/Doctrine/DoctrineVectorStore.php
@@ -23,7 +23,7 @@ final class DoctrineVectorStore extends VectorStoreBase
      */
     public function __construct(private readonly EntityManagerInterface $entityManager, public readonly string $entityClassName)
     {
-        if (! class_exists(EntityManagerInterface::class)) {
+        if (! interface_exists(EntityManagerInterface::class)) {
             throw new \RuntimeException('To use this functionality, you must install the `doctrine/orm` package: `composer require doctrine/orm`.');
         }
 


### PR DESCRIPTION
The last version contains a bug when checking for Doctrine/ORM installation, test is made on `class_exists` on an interface, resulting on an error. Fixing using `interface_exists`