### PR TITLE
Allow openai client of 0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.1.0",
         "guzzlehttp/guzzle": "^7.1.0",
         "nunomaduro/termwind": "^1.15",
-        "openai-php/client": "^0.6.4 || ^v0.7.3",
+        "openai-php/client": "^0.6.4 || ^v0.7.3 || ^v0.8.0",
         "phpoffice/phpword": "^1.1",
         "smalot/pdfparser": "^2.7",
         "symfony/cache": "*",


### PR DESCRIPTION
In order to use this library with the latest client and symfony bundle, this updates the requirement to 0.8.