### PR TITLE
Allow supplying a custom client to OpenAIChat

### DIFF
--- a/docusaurus/docs/usage.md
+++ b/docusaurus/docs/usage.md
@@ -13,6 +13,8 @@ You can also create an OpenAIConfig object and pass it to the constructor of the
 
 ```php
 $config = new OpenAIConfig();
+// optional: wire a PSR-18 HTTP client, such as symfony/http-client
+$config->client = new PSR18Client();
 $config->apiKey = 'fakeapikey';
 $chat = new OpenAIChat($config);
 ```

--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -35,11 +35,16 @@ class OpenAIChat
 
     public function __construct(?OpenAIConfig $config = null)
     {
-        $apiKey = $config->apiKey ?? getenv('OPENAI_API_KEY');
-        if (! $apiKey) {
-            throw new Exception('You have to provide a OPENAI_API_KEY env var to request OpenAI .');
+        if ($config instanceof OpenAIConfig && $config->client instanceof Client) {
+            $this->client = $config->client;
+        } else {
+            $apiKey = $config->apiKey ?? getenv('OPENAI_API_KEY');
+            if (! $apiKey) {
+                throw new Exception('You have to provide a OPENAI_API_KEY env var to request OpenAI .');
+            }
+
+            $this->client = OpenAI::client($apiKey);
         }
-        $this->client = OpenAI::client($apiKey);
         $this->model = $config->model ?? OpenAIChatModel::Gpt4Turbo->getModelName();
     }
 

--- a/src/OpenAIConfig.php
+++ b/src/OpenAIConfig.php
@@ -2,9 +2,13 @@
 
 namespace LLPhant;
 
+use OpenAI\Client;
+
 class OpenAIConfig
 {
     public string $apiKey;
+
+    public ?Client $client = null;
 
     public string $model;
 }

--- a/tests/Integration/Chat/OpenAIChatTest.php
+++ b/tests/Integration/Chat/OpenAIChatTest.php
@@ -8,6 +8,20 @@ use LLPhant\Chat\FunctionInfo\FunctionInfo;
 use LLPhant\Chat\FunctionInfo\Parameter;
 use LLPhant\Chat\OpenAIChat;
 use LLPhant\OpenAIConfig;
+use OpenAI\Client;
+
+it('can be supplied with a custom client', function () {
+    $client = \Mockery::mock(Client::class);
+    $client->shouldReceive('chat')->once();
+
+    $config = new OpenAIConfig();
+    $config->client = $client;
+
+    $chat = new OpenAIChat($config);
+    $chat->setSystemMessage('Whatever we ask you, you MUST answer "ok"');
+    $response = $chat->generateText('what is one + one ?');
+    expect($response)->toBeString();
+});
 
 it('can generate some stuff', function () {
     $chat = new OpenAIChat();


### PR DESCRIPTION
Allows supplying a custom client.

Use cases include to supply a custom http client