### PR TITLE
Added ChatInterface + Ollama support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 We designed this framework to be as simple as possible, while still providing you with the tools you need to build powerful apps.
 It is compatible with Symfony and Laravel.
 
-For the moment only OpenAI is supported, if you want to use other LLMs, you can use [genossGPT](https://github.com/OpenGenenerativeAI/GenossGPT)
+We are working to expand the support of different LLMs. Right now, we are supporting [OpenAI](https://openai.com/blog/openai-api) and [Ollama](https://ollama.ai/) that can be used to run LLM locally such as [Llama 2](https://llama.meta.com/).
+
+If you want to use other LLMs, you can use [genossGPT](https://github.com/OpenGenenerativeAI/GenossGPT)
 as a proxy.
 
 We want to thank few amazing projects that we use here or inspired us:
@@ -62,6 +64,11 @@ If you want to discover more usage from the community, you can see here a list o
 You can also see other use cases on [Qdrant's website](https://qdrant.tech/use-cases/).
 
 ## Usage
+
+You can use OpenAI or Ollama as LLM.
+
+### OpenAI
+
 The most simple to allow the call to OpenAI is to set the OPENAI_API_KEY environment variable.
 
 ```bash
@@ -76,37 +83,43 @@ $config->apiKey = 'fakeapikey';
 $chat = new OpenAIChat($config);
 ```
 
+### Ollama
+
+If you want to use Ollama, you can just specify the model to use using the `OllamaConfig` object and pass it to the `OllamaChat`.
+
+```php
+$config = new OllamaConfig();
+$config->model = 'llama2';
+$chat = new OllamaChat($config);
+```
+
 ### Chat
+
 > 💡 This class can be used to generate content, to create a chatbot or to create a text summarizer.
 
-The API to generate text using OpenAI will only be from the chat API.
-So even if you want to generate a completion for a simple question under the hood it will use the chat API.
-This is why this class is called OpenAIChat.
-We can use it to simply generate text from a prompt.
+You can use the `OpenAIChat` or `OllamaChat` to generate text or to create a chat.
 
+We can use it to simply generate text from a prompt.
 This will ask directly an answer from the LLM.
 ```php
-$chat = new OpenAIChat();
 $response = $chat->generateText('what is one + one ?'); // will return something like "Two"
 ```
 
 If you want to display in your frontend a stream of text like in ChatGPT you can use the following method.
 ```php
-$chat = new OpenAIChat();
 return $chat->generateStreamOfText('can you write me a poem of 10 lines about life ?');
 ```
 
 You can add instruction so the LLM will behave in a specific manner.
 
 ```php
-$chat = new OpenAIChat();
 $chat->setSystemMessage('Whatever we ask you, you MUST answer "ok"');
 $response = $chat->generateText('what is one + one ?'); // will return "ok"
 ```
 
 ## Tools
 
-This feature is amazing.
+This feature is amazing and is available only for OpenAI.
 
 OpenAI has refined its model to determine whether tools should be invoked.
 To utilize this, simply send a description of the available tools to OpenAI,
@@ -181,6 +194,7 @@ The array type is supported but still experimental.
 
 ### Embeddings
 > 💡 Embeddings are used to compare two texts and see how similar they are. This is the base of semantic search.
+
 An embedding is a vector representation of a text that captures the meaning of the text.
 It is a float array of 1536 elements for OpenAI.
 

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     "require": {
         "php": "^8.1.0",
         "guzzlehttp/guzzle": "^7.1.0",
+        "guzzlehttp/psr7": "^2.6",
         "nunomaduro/termwind": "^1.15 || ^2.0",
         "openai-php/client": "^v0.7.7 || ^v0.8.0",
         "phpoffice/phpword": "^1.1",
-        "smalot/pdfparser": "^2.7",
-        "symfony/cache": "*",
-        "symfony/http-foundation": "^6.0.0 || ^7.0.0"
+        "psr/http-message": "^2.0",
+        "smalot/pdfparser": "^2.7"
     },
     "suggest": {
         "doctrine/orm": "This is required for the DoctrineVectoreStore. This should be working with any version ^2.13.0",
@@ -27,7 +27,6 @@
     "require-dev": {
         "doctrine/orm": "^2.13.0",
         "elasticsearch/elasticsearch": "^8.10",
-        "guzzlehttp/psr7": "^2.5.0",
         "hkulekci/qdrant": "^v0.4",
         "laravel/pint": "^v1.13.7",
         "mockery/mockery": "^1.6",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: max
+    level: 8
     paths:
         - src
     excludePaths:

--- a/src/Chat/ChatInterface.php
+++ b/src/Chat/ChatInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace LLPhant\Chat;
+
+use LLPhant\Chat\FunctionInfo\FunctionInfo;
+use Psr\Http\Message\StreamInterface;
+
+interface ChatInterface
+{
+    public function generateText(string $prompt): string;
+
+    public function generateTextOrReturnFunctionCalled(string $prompt): string|FunctionInfo;
+
+    public function generateStreamOfText(string $prompt): StreamInterface;
+
+    /** @param Message[] $messages */
+    public function generateChat(array $messages): string;
+
+    /** @param Message[] $messages */
+    public function generateChatStream(array $messages): StreamInterface;
+
+    public function setSystemMessage(string $message): void;
+
+    /** @param FunctionInfo[] $tools */
+    public function setTools(array $tools): void;
+
+    public function addTool(FunctionInfo $functionInfo): void;
+
+    /** @param FunctionInfo[] $functions */
+    public function setFunctions(array $functions): void;
+
+    public function addFunction(FunctionInfo $functionInfo): void;
+}

--- a/src/Chat/OllamaChat.php
+++ b/src/Chat/OllamaChat.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLPhant\Chat;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Utils;
+use JsonException;
+use LLPhant\Chat\FunctionInfo\FunctionInfo;
+use LLPhant\Exception\FormatException;
+use LLPhant\Exception\HttpExcetion;
+use LLPhant\Exception\MissingFeatureExcetion;
+use LLPhant\Exception\MissingParameterExcetion;
+use LLPhant\OllamaConfig;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Ollama chat
+ *
+ * @see https://ollama.ai/
+ */
+class OllamaChat implements ChatInterface
+{
+    private Message $systemMessage;
+
+    public Client $client;
+
+    public function __construct(protected OllamaConfig $config)
+    {
+        $this->config = $config;
+        if (! isset($config->model)) {
+            throw new MissingParameterExcetion('You need to specify a model for Ollama');
+        }
+        $this->client = new Client([
+            'base_uri' => $config->url,
+        ]);
+    }
+
+    /**
+     * Generate a completion
+     *
+     * @see https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-completion
+     */
+    public function generateText(string $prompt): string
+    {
+        $response = $this->sendRequest(
+            'POST',
+            'generate',
+            [
+                'model' => $this->config->model,
+                'prompt' => $prompt,
+                'stream' => false,
+            ]
+        );
+        $json = $this->decodeJson($response->getBody()->getContents());
+
+        return $json['response'];
+    }
+
+    /**
+     * Ollama does not support (yet) functions, this is an alias of generateText
+     */
+    public function generateTextOrReturnFunctionCalled(string $prompt): string|FunctionInfo
+    {
+        return $this->generateText($prompt);
+    }
+
+    public function generateStreamOfText(string $prompt): StreamInterface
+    {
+        $response = $this->sendRequest(
+            'POST',
+            'generate',
+            [
+                'model' => $this->config->model,
+                'prompt' => $prompt,
+                'stream' => true,
+            ]
+        );
+
+        return $this->decodeStreamOfText($response);
+    }
+
+    /**
+     * Send a chat request
+     *
+     * @see https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion
+     *
+     * @param  Message[]  $messages
+     */
+    public function generateChat(array $messages): string
+    {
+        $response = $this->sendRequest(
+            'POST',
+            'chat',
+            [
+                'model' => $this->config->model,
+                'messages' => $this->prepareMessages($messages),
+                'stream' => false,
+            ]
+        );
+        $json = $this->decodeJson($response->getBody()->getContents());
+
+        return $json['message']['content'];
+    }
+
+    /** @param Message[] $messages */
+    public function generateChatStream(array $messages): StreamInterface
+    {
+        $response = $this->sendRequest(
+            'POST',
+            'chat',
+            [
+                'model' => $this->config->model,
+                'messages' => $this->prepareMessages($messages),
+                'stream' => true,
+            ]
+        );
+
+        return $this->decodeStreamOfChat($response);
+    }
+
+    public function setSystemMessage(string $message): void
+    {
+        $this->systemMessage = Message::system($message);
+    }
+
+    /** @param FunctionInfo[] $tools */
+    public function setTools(array $tools): void
+    {
+        throw new MissingFeatureExcetion('This feature is not supported');
+    }
+
+    public function addTool(FunctionInfo $functionInfo): void
+    {
+        throw new MissingFeatureExcetion('This feature is not supported');
+    }
+
+    /** @param FunctionInfo[] $functions */
+    public function setFunctions(array $functions): void
+    {
+        throw new MissingFeatureExcetion('This feature is not supported');
+    }
+
+    public function addFunction(FunctionInfo $functionInfo): void
+    {
+        throw new MissingFeatureExcetion('This feature is not supported');
+    }
+
+    /**
+     * Send the HTTP request to Ollama API endpoint
+     *
+     * @param  mixed[]  $json
+     *
+     * @see https://github.com/ollama/ollama/blob/main/docs/api.md
+     */
+    protected function sendRequest(string $method, string $path, array $json): ResponseInterface
+    {
+        $response = $this->client->request($method, $path, ['json' => $json]);
+        $status = $response->getStatusCode();
+        if ($status < 200 || $status >= 300) {
+            throw new HttpExcetion(sprintf(
+                'HTTP error from Ollama (%d): %s',
+                $status,
+                $response->getBody()->getContents()
+            ));
+        }
+
+        return $response;
+    }
+
+    /**
+     * Decode a JSON string into an array
+     *
+     * @return mixed[]
+     */
+    protected function decodeJson(string $json): array
+    {
+        try {
+            return json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new FormatException(sprintf(
+                'JSON error decoding: %s',
+                $e->getMessage()
+            ));
+        }
+    }
+
+    /**
+     * Decode a stream of text using the application/x-ndjson format
+     */
+    protected function decodeStreamOfText(ResponseInterface $response): StreamInterface
+    {
+        // Split the application/x-ndjson response into json responses
+        $stream = explode("\n", $response->getBody()->getContents());
+        $generator = function ($stream) {
+            foreach ($stream as $partialResponse) {
+                $json = $this->decodeJson($partialResponse);
+                if ((bool) $json['done']) {
+                    break;
+                }
+                if (! isset($json['response'])) {
+                    continue;
+                }
+                if (empty($json['response'])) {
+                    continue;
+                }
+                yield $json['response'];
+            }
+        };
+
+        return Utils::streamFor($generator($stream));
+    }
+
+    /**
+     * Decode a stream of chat using the application/x-ndjson format
+     */
+    protected function decodeStreamOfChat(ResponseInterface $response): StreamInterface
+    {
+        // Split the application/x-ndjson response into json responses
+        $stream = explode("\n", $response->getBody()->getContents());
+        $generator = function ($stream) {
+            foreach ($stream as $partialResponse) {
+                $json = $this->decodeJson($partialResponse);
+                if ((bool) $json['done']) {
+                    break;
+                }
+                if (! isset($json['message'])) {
+                    continue;
+                }
+                if ($json['message']['role'] !== 'assistant') {
+                    continue;
+                }
+                yield $json['message']['content'];
+            }
+        };
+
+        return Utils::streamFor($generator($stream));
+    }
+
+    /**
+     * Prepare the messages for the chat using the format:
+     * { "role": "xxx", "content": "yyy"}
+     *
+     * @param  Message[]  $messages
+     * @return mixed[]
+     *
+     * @see https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion
+     */
+    protected function prepareMessages(array $messages): array
+    {
+        $response = [];
+        // The system message is always the first
+        if (isset($this->systemMessage->role)) {
+            $response[] = [
+                'role' => $this->systemMessage->role,
+                'content' => $this->systemMessage->content,
+            ];
+        }
+        foreach ($messages as $msg) {
+            $response[] = [
+                'role' => $msg->role,
+                'content' => $msg->content,
+            ];
+        }
+
+        return $response;
+    }
+}

--- a/src/Exception/FormatException.php
+++ b/src/Exception/FormatException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLPhant\Exception;
+
+use Exception;
+
+class FormatException extends Exception implements LLPhantException
+{
+}

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLPhant\Exception;
+
+use Exception;
+
+class HttpExcetion extends Exception implements LLPhantException
+{
+}

--- a/src/Exception/LLPhantException.php
+++ b/src/Exception/LLPhantException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLPhant\Exception;
+
+use Throwable;
+
+interface LLPhantException extends Throwable
+{
+}

--- a/src/Exception/MissingFeatureException.php
+++ b/src/Exception/MissingFeatureException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLPhant\Exception;
+
+use Exception;
+
+class MissingFeatureExcetion extends Exception implements LLPhantException
+{
+}

--- a/src/Exception/MissingParameterException.php
+++ b/src/Exception/MissingParameterException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLPhant\Exception;
+
+use Exception;
+
+class MissingParameterExcetion extends Exception implements LLPhantException
+{
+}

--- a/src/OllamaConfig.php
+++ b/src/OllamaConfig.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLPhant;
+
+class OllamaConfig
+{
+    public string $model;
+
+    public string $url = 'http://localhost:11434/api/';
+
+    public bool $stream = false;
+}

--- a/src/OpenAIConfig.php
+++ b/src/OpenAIConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LLPhant;
 
 use OpenAI\Client;

--- a/src/Query/SemanticSearch/QuestionAnswering.php
+++ b/src/Query/SemanticSearch/QuestionAnswering.php
@@ -7,7 +7,7 @@ use LLPhant\Chat\OpenAIChat;
 use LLPhant\Embeddings\Document;
 use LLPhant\Embeddings\EmbeddingGenerator\EmbeddingGeneratorInterface;
 use LLPhant\Embeddings\VectorStores\VectorStoreBase;
-use Symfony\Component\HttpFoundation\StreamedResponse;
+use Psr\Http\Message\StreamInterface;
 
 class QuestionAnswering
 {
@@ -43,7 +43,7 @@ class QuestionAnswering
      * @param  Message[]  $messages
      * @param  array<string, string|int>|array<mixed[]>  $additionalArguments
      */
-    public function answerQuestionFromChat(array $messages, int $k = 4, array $additionalArguments = []): StreamedResponse
+    public function answerQuestionFromChat(array $messages, int $k = 4, array $additionalArguments = []): StreamInterface
     {
         // First we need to give the context to openAI with the good instructions
         $userQuestion = $messages[count($messages) - 1]->content;

--- a/tests/Unit/Chat/OllamaChatTest.php
+++ b/tests/Unit/Chat/OllamaChatTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit\Chat;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use LLPhant\Chat\Message;
+use LLPhant\Chat\OllamaChat;
+use LLPhant\Exception\MissingParameterExcetion;
+use LLPhant\OllamaConfig;
+use Psr\Http\Message\StreamInterface;
+
+it('error when construct with no model', function () {
+    $config = new OllamaConfig();
+    $chat = new OllamaChat($config);
+})->throws(MissingParameterExcetion::class, 'You need to specify a model for Ollama');
+
+it('no error when construct with model', function () {
+    $config = new OllamaConfig();
+    $config->model = 'test';
+    $chat = new OllamaChat($config);
+    expect(isset($chat))->toBeTrue();
+});
+
+it('returns a stream response using generateStreamOfText()', function () {
+    $mock = new MockHandler([
+        new Response(200, [], 'This is the response from Ollama'),
+    ]);
+    $handlerStack = HandlerStack::create($mock);
+    $client = new Client(['handler' => $handlerStack]);
+
+    $config = new OllamaConfig();
+    $config->model = 'test';
+    $chat = new OllamaChat($config);
+    $chat->client = $client;
+
+    $response = $chat->generateStreamOfText('this is the prompt question');
+    expect($response)->toBeInstanceof(StreamInterface::class);
+});
+
+it('returns a stream response using generateChatStream()', function () {
+    $mock = new MockHandler([
+        new Response(200, [], 'This is the response from Ollama'),
+    ]);
+    $handlerStack = HandlerStack::create($mock);
+    $client = new Client(['handler' => $handlerStack]);
+
+    $config = new OllamaConfig();
+    $config->model = 'test';
+    $chat = new OllamaChat($config);
+    $chat->client = $client;
+
+    $response = $chat->generateChatStream([Message::user('here the question')]);
+    expect($response)->toBeInstanceof(StreamInterface::class);
+});

--- a/tests/Unit/Chat/OpenAIChatTest.php
+++ b/tests/Unit/Chat/OpenAIChatTest.php
@@ -2,12 +2,56 @@
 
 namespace Tests\Unit\Chat;
 
+use GuzzleHttp\Psr7\Response;
+use LLPhant\Chat\Message;
 use LLPhant\Chat\OpenAIChat;
 use LLPhant\OpenAIConfig;
+use Mockery;
+use OpenAI\Client;
+use OpenAI\Contracts\TransporterContract;
+use Psr\Http\Message\StreamInterface;
 
 it('no error when construct with no model', function () {
     $config = new OpenAIConfig();
     $config->apiKey = 'fakeapikey';
     $chat = new OpenAIChat($config);
     expect(isset($chat))->toBeTrue();
+});
+
+it('returns a stream response using generateStreamOfText()', function () {
+    $response = new Response(
+        200,
+        [],
+        'This is the response from OpenAI'
+    );
+    $transport = Mockery::mock(TransporterContract::class);
+    $transport->allows([
+        'requestStream' => $response,
+    ]);
+
+    $config = new OpenAIConfig();
+    $config->client = new Client($transport);
+    $chat = new OpenAIChat($config);
+
+    $response = $chat->generateStreamOfText('this is the prompt question');
+    expect($response)->toBeInstanceof(StreamInterface::class);
+});
+
+it('returns a stream response using generateChatStream()', function () {
+    $response = new Response(
+        200,
+        [],
+        'This is the response from OpenAI'
+    );
+    $transport = Mockery::mock(TransporterContract::class);
+    $transport->allows([
+        'requestStream' => $response,
+    ]);
+
+    $config = new OpenAIConfig();
+    $config->client = new Client($transport);
+    $chat = new OpenAIChat($config);
+
+    $response = $chat->generateChatStream([Message::user('here the question')]);
+    expect($response)->toBeInstanceof(StreamInterface::class);
 });


### PR DESCRIPTION
This PR is a first proposal to extend the support of other LLMs introducing a `ChatInterface` (see #65). 
I draft a first support for [Ollama](https://ollama.ai/) project. Using Ollama you can run a local LLM, such as [Llama 2](https://ollama.ai/library/llama2). A full list of supported LLM is available [here](https://ollama.ai/library).

This PR includes the following changes:
- Removed the `HttpFoundation` in favor of PSR-7;
- Added custom Exceptions using a common `LLPhantException` interface;
- Added a `ChatInterface` for proposing alternative LLMs;
- Added a basic support of Ollama implementing the `OllamaChat` class;
- Updated the `README.md` including some notes for Ollama usage;

