### PR TITLE
Add MistralAIChat

### DIFF
--- a/src/Chat/Enums/MistralAIChatModel.php
+++ b/src/Chat/Enums/MistralAIChatModel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace LLPhant\Chat\Enums;
+
+enum MistralAIChatModel
+{
+    case tiny;
+    case small;
+    case medium;
+
+    public function getModelName(): string
+    {
+        return match ($this) {
+            MistralAIChatModel::tiny => 'mistral-tiny',
+            MistralAIChatModel::small => 'mistral-small',
+            MistralAIChatModel::medium => 'mistral-medium',
+        };
+    }
+}

--- a/src/Chat/MistralAIChat.php
+++ b/src/Chat/MistralAIChat.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace LLPhant\Chat;
+
+use Exception;
+use LLPhant\Chat\Enums\MistralAIChatModel;
+use LLPhant\Chat\FunctionInfo\FunctionInfo;
+use LLPhant\Exception\MissingFeatureExcetion;
+use LLPhant\OpenAIConfig;
+use OpenAI\Client;
+use OpenAI\Factory;
+
+use function getenv;
+
+class MistralAIChat extends OpenAIChat
+{
+    private const BASE_URL = 'api.mistral.ai/v1';
+
+    public function __construct(?OpenAIConfig $config = null)
+    {
+        if (! $config instanceof OpenAIConfig) {
+            $config = new OpenAIConfig();
+        }
+
+        if (! $config->client instanceof Client) {
+            $apiKey = $config->apiKey ?? getenv('MISTRAL_API_KEY');
+            if (! $apiKey) {
+                throw new Exception('You have to provide a MISTRAL_API_KEY env var to request Mistral AI.');
+            }
+
+            $clientFactory = new Factory();
+            $config->client = $clientFactory
+                ->withApiKey($apiKey)
+                ->withBaseUri(self::BASE_URL)
+                ->make();
+        }
+
+        $config->model ??= MistralAIChatModel::small->getModelName();
+        parent::__construct($config);
+    }
+
+    /** @param  FunctionInfo[]  $tools */
+    public function setTools(array $tools): void
+    {
+        throw new MissingFeatureExcetion('This feature is not supported');
+    }
+
+    public function addTool(FunctionInfo $functionInfo): void
+    {
+        throw new MissingFeatureExcetion('This feature is not supported');
+    }
+
+    /** @param  FunctionInfo[]  $functions */
+    public function setFunctions(array $functions): void
+    {
+        throw new MissingFeatureExcetion('This feature is not supported');
+    }
+
+    public function addFunction(FunctionInfo $functionInfo): void
+    {
+        throw new MissingFeatureExcetion('This feature is not supported');
+    }
+}

--- a/tests/Integration/Chat/MistralAIChatTest.php
+++ b/tests/Integration/Chat/MistralAIChatTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Chat;
+
+use LLPhant\Chat\MistralAIChat;
+use LLPhant\OpenAIConfig;
+use OpenAI\Client;
+
+it('can be supplied with a custom client', function () {
+    $client = \Mockery::mock(Client::class);
+    $client->shouldReceive('chat')->once();
+
+    $config = new OpenAIConfig();
+    $config->client = $client;
+
+    $chat = new MistralAIChat($config);
+    $chat->setSystemMessage('Whatever we ask you, you MUST answer "ok"');
+    $response = $chat->generateText('what is one + one ?');
+    expect($response)->toBeString();
+});
+
+it('can generate some stuff', function () {
+    $chat = new MistralAIChat();
+    $response = $chat->generateText('what is one + one ?');
+    expect($response)->toBeString();
+});
+
+it('can generate some stuff with a system prompt', function () {
+    $chat = new MistralAIChat();
+    $chat->setSystemMessage('Whatever we ask you, you MUST answer "ok"');
+    $response = $chat->generateText('what is one + one ?');
+    expect(strtolower($response))->toBe('ok');
+});
+
+it('can load any existing model', function () {
+    $config = new OpenAIConfig();
+    $config->model = 'mistral-tiny';
+    $chat = new MistralAIChat($config);
+    $response = $chat->generateText('one + one ?');
+    expect($response)->toBeString();
+});

--- a/tests/Unit/Chat/MistralAIChatTest.php
+++ b/tests/Unit/Chat/MistralAIChatTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit\Chat;
+
+use GuzzleHttp\Psr7\Response;
+use LLPhant\Chat\Message;
+use LLPhant\Chat\MistralAIChat;
+use LLPhant\OpenAIConfig;
+use Mockery;
+use OpenAI\Client;
+use OpenAI\Contracts\TransporterContract;
+use Psr\Http\Message\StreamInterface;
+
+it('no error when construct with no model', function () {
+    $config = new OpenAIConfig();
+    $config->apiKey = 'fakeapikey';
+    $chat = new MistralAIChat($config);
+    expect(isset($chat))->toBeTrue();
+});
+
+it('returns a stream response using generateStreamOfText()', function () {
+    $response = new Response(
+        200,
+        [],
+        'This is the response from Mistral AI'
+    );
+    $transport = Mockery::mock(TransporterContract::class);
+    $transport->allows([
+        'requestStream' => $response,
+    ]);
+
+    $config = new OpenAIConfig();
+    $config->client = new Client($transport);
+    $chat = new MistralAIChat($config);
+
+    $response = $chat->generateStreamOfText('this is the prompt question');
+    expect($response)->toBeInstanceof(StreamInterface::class);
+});
+
+it('returns a stream response using generateChatStream()', function () {
+    $response = new Response(
+        200,
+        [],
+        'This is the response from Mistral AI'
+    );
+    $transport = Mockery::mock(TransporterContract::class);
+    $transport->allows([
+        'requestStream' => $response,
+    ]);
+
+    $config = new OpenAIConfig();
+    $config->client = new Client($transport);
+    $chat = new MistralAIChat($config);
+
+    $response = $chat->generateChatStream([Message::user('here the question')]);
+    expect($response)->toBeInstanceof(StreamInterface::class);
+});


### PR DESCRIPTION
Thanks for your work !

Here is a MistralAIChat to access Mistral.ai API
It works the same way as OpenAI, since the Mistral API has th same API definition.

This feature needs to access a MISTRAL_API_KEY env var to be authorized.
It uses the OpenAIChat as the parent class, and just change the OpenAIConfig object attributes to reflect what's needed for Mistral.

Because Mistral uses the same API def for completion, I didn't want to create a MistralAIConfig. In fact, it uses the same PHP SDK from OpenAI.

As the Mistral API does not allow the use of function yet, I used the same MissingFeatureExcetion as OllamaChat.

Here is 2 examples to let you see what I though :

```
public function askSimpleQuestion(
    string $question,
): string {
    $chat = new MistralAIChat();
    $response = $chat->generateText($question);

    return $response;
}

public function askAugmentedQuestionSmallFile(
    string $question,
    string $filePath,
): string {
    $vectorStore = new FileSystemVectorStore('mistral-small-file-vectorstore.json');
    $embeddingGenerator = new MistralEmbeddingGenerator();

    if ($vectorStore->getNumberOfDocuments() === 0) {
        $reader = new FileDataReader($filePath);
        $documents = $reader->getDocuments();
        $splittedDocuments = DocumentSplitter::splitDocuments($documents, 800);
        $formattedDocuments = EmbeddingFormatter::formatEmbeddings($splittedDocuments);
        $embededDocuments = $embeddingGenerator->embedDocuments($formattedDocuments);

        $vectorStore->addDocuments($embededDocuments);
    }

    $qa = new QuestionAnswering(
        $vectorStore,
        $embeddingGenerator,
        new MistralAIChat()
    );

    return $qa->answerQuestion($question);
}
```
Let me know what you think !