### PR TITLE
Allow custom client for OpenAI Embedding generators

### DIFF
--- a/src/Embeddings/EmbeddingGenerator/OpenAI/AbstractOpenAIEmbeddingGenerator.php
+++ b/src/Embeddings/EmbeddingGenerator/OpenAI/AbstractOpenAIEmbeddingGenerator.php
@@ -23,11 +23,16 @@ abstract class AbstractOpenAIEmbeddingGenerator implements EmbeddingGeneratorInt
      */
     public function __construct(?OpenAIConfig $config = null)
     {
-        $apiKey = $config->apiKey ?? getenv('OPENAI_API_KEY');
-        if (! $apiKey) {
-            throw new Exception('You have to provide a OPENAI_API_KEY env var to request OpenAI .');
+        if ($config instanceof OpenAIConfig && $config->client instanceof Client) {
+            $this->client = $config->client;
+        } else {
+            $apiKey = $config->apiKey ?? getenv('OPENAI_API_KEY');
+            if (! $apiKey) {
+                throw new Exception('You have to provide a OPENAI_API_KEY env var to request OpenAI .');
+            }
+
+            $this->client = OpenAI::client($apiKey);
         }
-        $this->client = OpenAI::client($apiKey);
     }
 
     /**


### PR DESCRIPTION
Hello,

As we have in the OpenAIChat, I would like to be able to specify a custom client in the embedding generators.

I updated the construct of AbstractOpenAIEmbeddingGenerator to reflect the code in OpenAIChat.

For more context, we are in a Symfony app, and we have defined a scoped httpclient. This client can be injected in a service, and then passed to either the LLPhant chat or generator.

What do you think ?