### PR TITLE
Allow using custom model options

### DIFF
--- a/src/Chat/ChatInterface.php
+++ b/src/Chat/ChatInterface.php
@@ -30,4 +30,6 @@ interface ChatInterface
     public function setFunctions(array $functions): void;
 
     public function addFunction(FunctionInfo $functionInfo): void;
+
+    public function setModelOption(string $option, mixed $value): void;
 }

--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -25,6 +25,9 @@ class OpenAIChat implements ChatInterface
 
     public string $model;
 
+    /** @var array<string, mixed> */
+    private array $modelOptions = [];
+
     private Message $systemMessage;
 
     /** @var FunctionInfo[] */
@@ -47,6 +50,7 @@ class OpenAIChat implements ChatInterface
             $this->client = OpenAI::client($apiKey);
         }
         $this->model = $config->model ?? OpenAIChatModel::Gpt4Turbo->getModelName();
+        $this->modelOptions = $config->modelOptions ?? [];
     }
 
     public function generateText(string $prompt): string
@@ -141,6 +145,11 @@ class OpenAIChat implements ChatInterface
         $this->tools[] = $functionInfo;
     }
 
+    public function setModelOption(string $option, mixed $value): void
+    {
+        $this->modelOptions[$option] = $value;
+    }
+
     private function generate(string $prompt): CreateResponse
     {
         $messages = $this->createOpenAIMessagesFromPrompt($prompt);
@@ -206,7 +215,7 @@ class OpenAIChat implements ChatInterface
 
     /**
      * @param  Message[]  $messages
-     * @return array{model: string, messages: Message[], functions?: mixed[]}
+     * @return array<string, mixed>
      */
     private function getOpenAiArgs(array $messages): array
     {
@@ -218,10 +227,9 @@ class OpenAIChat implements ChatInterface
 
         $finalMessages = array_merge($finalMessages, $messages);
 
-        $openAiArgs = [
-            'model' => $this->model,
-            'messages' => $finalMessages,
-        ];
+        $openAiArgs = $this->modelOptions;
+
+        $openAiArgs = [...$openAiArgs, 'model' => $this->model, 'messages' => $finalMessages];
 
         if ($this->tools !== []) {
             $openAiArgs['tools'] = ToolFormatter::formatFunctionsToOpenAITools($this->tools);

--- a/src/OllamaConfig.php
+++ b/src/OllamaConfig.php
@@ -13,4 +13,17 @@ class OllamaConfig
     public bool $stream = false;
 
     public bool $formatJson = false;
+
+    /**
+     * model options, example:
+     * - options
+     * - template
+     * - raw
+     * - keep_alive
+     *
+     * @see https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-completion
+     *
+     * @var array<string, mixed>
+     */
+    public array $modelOptions = [];
 }

--- a/src/OpenAIConfig.php
+++ b/src/OpenAIConfig.php
@@ -13,4 +13,24 @@ class OpenAIConfig
     public ?Client $client = null;
 
     public string $model;
+
+    /**
+     * model options, example:
+     * - temperature
+     * - max_tokens
+     * - presence_penalty
+     * - frequency_penalty
+     * - n
+     * - logprobs
+     * - top_logprobs
+     * - stop
+     * - user
+     * - top_p
+     * - response_format
+     *
+     * @see https://platform.openai.com/docs/api-reference/chat/create
+     *
+     * @var array<string, mixed>
+     */
+    public array $modelOptions = [];
 }


### PR DESCRIPTION
Hi,

This PR to allow the use of custom values for model options, like those one below :

- temperature
- max_tokens
- presence_penalty
- frequency_penalty
- n
- logprobs
- top_logprobs
- stop
- user
- top_p
- response_format

I used a simple assoc array, instead of defining each options in the OpenAIConfig object for 2 reasons:

- 1 simplicity
- 2 versatility. Since OpenAIConfig object is shared with both OpenAIChat and MistralAIChat, and even if the options should be the same, we can't know for sure they won't diverge. It allow us to simply put some keys that will be transfered to the LLM API.

What do you think ?