### PR TITLE
Store the last response object from OpenAI

### DIFF
--- a/docusaurus/docs/usage.md
+++ b/docusaurus/docs/usage.md
@@ -58,6 +58,85 @@ $messages = [
 
 $response = $chat->generateChat($messages);
 ```
+## Get the token usage
+
+When using OpenAI is important to know how many token are you using
+since the [model pricing](https://openai.com/api/pricing/) is token based.
+
+You can retrieve the total token usage using the `OpenAIChat::getTotalTokens()`
+function, as follows:
+```php
+$chat = new OpenAIChat();
+
+$answer = $chat->generateText('what is one + one ?');
+printf("%s\n", $answer); # One plus one equals two
+printf("Total tokens usage: %d\n", $chat->getTotalTokens()); # 19
+
+$answer = $chat->generateText('And what is two + two ?');
+printf("%s\n", $answer); # Two plus two equals four
+printf("Total tokens usage: %d\n", $chat->getTotalTokens()); # 39
+```
+
+The `getTotalTokens()` is an incremental value that is increased on each
+API call. For instance, in the previous example the first `what is one + one ?`
+generated 19 tokens and the second call 20 tokens. The total number of
+tokens is than 19 + 20 = 39 tokens.
+
+## Get the last response from OpenAI
+
+If you want to inspect the last API response from OpenAI you can use the function
+`OpenAIChat::getLastReponse()` function.
+
+This function returns an [OpenAI\Responses\Chat\CreateResponse](https://github.com/openai-php/client/blob/main/src/Responses/Chat/CreateResponse.php)
+that contains the following properties:
+
+```php
+namespace OpenAI\Responses\Chat;
+
+class CreateResponse
+{
+        public readonly string $id;
+        public readonly string $object;
+        public readonly int $created;
+        public readonly string $model;
+        public readonly ?string $systemFingerprint;
+        public readonly array $choices;
+        public readonly CreateResponseUsage $usage;
+}
+```
+
+The `usage` property is an object of the following [CreateResponseUsage](https://github.com/openai-php/client/blob/main/src/Responses/Chat/CreateResponseUsage.php)
+class:
+
+```php
+namespace OpenAI\Responses\Chat;
+
+final class CreateResponseUsage
+{
+    public readonly int $promptTokens;
+    public readonly ?int $completionTokens;
+    public readonly int $totalTokens;
+}
+```
+
+For instance, if you want to have specific information for the token usage,
+you can then access the `usage` properties and then the sub-property, as follows:
+
+```php
+$chat = new OpenAIChat();
+
+$answer = $chat->generateText('what is the capital of Italy ?');
+$response = $chat->getLastResponse();
+
+printf("Prompt tokens: %d\n", $response->usage->promptTokens);
+printf("Completion tokens: %d\n", $response->usage->completionTokens);
+printf("Total tokens: %d\n", $response->usage->totalTokens);
+```
+
+The value of the last `printf` is the total usage of the last response
+(promptTokens + completionTokens) and should not be confused with the
+`$chat->getTotalTokens()` function that is the sum of the previous totalTokens calls,
+including the last one `what is the capital of Italy ?`.
 
 ## Tools
 

--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -41,11 +41,8 @@ class OpenAIChat implements ChatInterface
 
     public ?FunctionInfo $requiredFunction = null;
 
-    public TokenUsage $usage;
-
     public function __construct(?OpenAIConfig $config = null)
     {
-        $this->usage = new TokenUsage();
         if ($config instanceof OpenAIConfig && $config->client instanceof Client) {
             $this->client = $config->client;
         } else {

--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -27,6 +27,8 @@ class OpenAIChat implements ChatInterface
 
     private ?CreateResponse $lastResponse = null;
 
+    private int $totalTokens = 0;
+
     /** @var array<string, mixed> */
     private array $modelOptions = [];
 
@@ -69,6 +71,11 @@ class OpenAIChat implements ChatInterface
         return $this->lastResponse;
     }
 
+    public function getTotalTokens(): int
+    {
+        return $this->totalTokens;
+    }
+
     public function generateTextOrReturnFunctionCalled(string $prompt): string|FunctionInfo
     {
         $answer = $this->generate($prompt);
@@ -101,6 +108,7 @@ class OpenAIChat implements ChatInterface
         $openAiArgs = $this->getOpenAiArgs($messages);
         $answer = $this->client->chat()->create($openAiArgs);
         $this->lastResponse = $answer;
+        $this->totalTokens += $answer->usage->totalTokens ?? 0;
 
         return $answer->choices[0]->message->content ?? '';
     }
@@ -166,6 +174,7 @@ class OpenAIChat implements ChatInterface
         $openAiArgs = $this->getOpenAiArgs($messages);
 
         $this->lastResponse = $this->client->chat()->create($openAiArgs);
+        $this->totalTokens += $this->lastResponse->usage->totalTokens ?? 0;
 
         return $this->lastResponse;
     }

--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -58,7 +58,6 @@ class OpenAIChat implements ChatInterface
     public function generateText(string $prompt): string
     {
         $answer = $this->generate($prompt);
-        $this->lastResponse = $answer;
 
         $this->handleTools($answer);
 
@@ -73,7 +72,6 @@ class OpenAIChat implements ChatInterface
     public function generateTextOrReturnFunctionCalled(string $prompt): string|FunctionInfo
     {
         $answer = $this->generate($prompt);
-        $this->lastResponse = $answer;
 
         $toolsToCall = $this->getToolsToCall($answer);
 
@@ -102,6 +100,7 @@ class OpenAIChat implements ChatInterface
     {
         $openAiArgs = $this->getOpenAiArgs($messages);
         $answer = $this->client->chat()->create($openAiArgs);
+        $this->lastResponse = $answer;
 
         return $answer->choices[0]->message->content ?? '';
     }
@@ -166,7 +165,9 @@ class OpenAIChat implements ChatInterface
         $messages = $this->createOpenAIMessagesFromPrompt($prompt);
         $openAiArgs = $this->getOpenAiArgs($messages);
 
-        return $this->client->chat()->create($openAiArgs);
+        $this->lastResponse = $this->client->chat()->create($openAiArgs);
+
+        return $this->lastResponse;
     }
 
     /**

--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -13,7 +13,6 @@ use OpenAI;
 use OpenAI\Client;
 use OpenAI\Responses\Chat\CreateResponse;
 use OpenAI\Responses\Chat\CreateResponseToolCall;
-use OpenAI\Responses\Chat\CreateResponseUsage;
 use OpenAI\Responses\Chat\CreateStreamedResponseToolCall;
 use OpenAI\Responses\StreamResponse;
 use Psr\Http\Message\StreamInterface;

--- a/tests/Fixtures/OpenAI/chat-response.json
+++ b/tests/Fixtures/OpenAI/chat-response.json
@@ -1,0 +1,21 @@
+{
+    "id": "chatcmpl-123",
+    "object": "chat.completion",
+    "created": 1677652288,
+    "model": "gpt-3.5-turbo-0125",
+    "system_fingerprint": "fp_44709d6fcb",
+    "choices": [{
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "\n\nHello there, how may I assist you today?"
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }],
+    "usage": {
+      "prompt_tokens": 9,
+      "completion_tokens": 12,
+      "total_tokens": 21
+    }
+  }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,14 @@
+<?php
+
+function fixture(string $name): array
+{
+    $content = file_get_contents(__DIR__."/Fixtures/$name.json");
+
+    if (! $content) {
+        throw new InvalidArgumentException(
+            "Cannot find fixture: [$name] at Fixtures/$name.json",
+        );
+    }
+
+    return json_decode($content, true);
+}

--- a/tests/Unit/Chat/OpenAIChatTest.php
+++ b/tests/Unit/Chat/OpenAIChatTest.php
@@ -9,6 +9,7 @@ use LLPhant\OpenAIConfig;
 use Mockery;
 use OpenAI\Client;
 use OpenAI\Contracts\TransporterContract;
+use OpenAI\ValueObjects\Transporter\Response as TransporterResponse;
 use Psr\Http\Message\StreamInterface;
 
 it('no error when construct with no model', function () {
@@ -54,4 +55,57 @@ it('returns a stream response using generateChatStream()', function () {
 
     $response = $chat->generateChatStream([Message::user('here the question')]);
     expect($response)->toBeInstanceof(StreamInterface::class);
+});
+
+it('returns last response using generateText()', function () {
+    $response = TransporterResponse::from(
+        fixture('OpenAI/chat-response'),
+        []
+    );
+    $transport = Mockery::mock(TransporterContract::class);
+    $transport->allows()->requestObject(anyArgs())->andReturns($response);
+
+    $config = new OpenAIConfig();
+    $config->client = new Client($transport);
+    $chat = new OpenAIChat($config);
+
+    $response = $chat->generateText('here the question');
+    $lastResponse = $chat->getLastResponse();
+
+    expect($lastResponse->id)->toBe('chatcmpl-123');
+    expect($lastResponse->object)->toBe('chat.completion');
+    expect($lastResponse->model)->toBe('gpt-3.5-turbo-0125');
+    expect($lastResponse->usage->promptTokens)->toBe(9);
+    expect($lastResponse->usage->completionTokens)->toBe(12);
+    expect($lastResponse->usage->totalTokens)->toBe(21);
+});
+
+it('returns last response using generateTextOrReturnFunctionCalled()', function () {
+    $response = TransporterResponse::from(
+        fixture('OpenAI/chat-response'),
+        []
+    );
+    $transport = Mockery::mock(TransporterContract::class);
+    $transport->allows()->requestObject(anyArgs())->andReturns($response);
+
+    $config = new OpenAIConfig();
+    $config->client = new Client($transport);
+    $chat = new OpenAIChat($config);
+
+    $response = $chat->generateText('here the question');
+    $lastResponse = $chat->getLastResponse();
+    expect($lastResponse->usage->promptTokens)->toBe(9);
+    expect($lastResponse->usage->completionTokens)->toBe(12);
+    expect($lastResponse->usage->totalTokens)->toBe(21);
+});
+
+it('returns empty (null) last response if no usage', function () {
+    
+    $transport = Mockery::mock(TransporterContract::class);
+
+    $config = new OpenAIConfig();
+    $config->client = new Client($transport);
+    $chat = new OpenAIChat($config);
+
+    expect($chat->getLastResponse())->toBe(null);
 });

--- a/tests/Unit/Chat/OpenAIChatTest.php
+++ b/tests/Unit/Chat/OpenAIChatTest.php
@@ -60,7 +60,7 @@ it('returns a stream response using generateChatStream()', function () {
 it('returns last response using generateText()', function () {
     $response = TransporterResponse::from(
         fixture('OpenAI/chat-response'),
-        []
+        ['x-request-id' => '1']
     );
     $transport = Mockery::mock(TransporterContract::class);
     $transport->allows()->requestObject(anyArgs())->andReturns($response);
@@ -83,7 +83,7 @@ it('returns last response using generateText()', function () {
 it('returns last response using generateTextOrReturnFunctionCalled()', function () {
     $response = TransporterResponse::from(
         fixture('OpenAI/chat-response'),
-        []
+        ['x-request-id' => '1']
     );
     $transport = Mockery::mock(TransporterContract::class);
     $transport->allows()->requestObject(anyArgs())->andReturns($response);

--- a/tests/Unit/Chat/OpenAIChatTest.php
+++ b/tests/Unit/Chat/OpenAIChatTest.php
@@ -100,7 +100,6 @@ it('returns last response using generateTextOrReturnFunctionCalled()', function 
 });
 
 it('returns empty (null) last response if no usage', function () {
-    
     $transport = Mockery::mock(TransporterContract::class);
 
     $config = new OpenAIConfig();

--- a/tests/Unit/Chat/OpenAIChatTest.php
+++ b/tests/Unit/Chat/OpenAIChatTest.php
@@ -108,3 +108,22 @@ it('returns empty (null) last response if no usage', function () {
 
     expect($chat->getLastResponse())->toBe(null);
 });
+
+it('returns total token usage generate() or generateTextOrReturnFunctionCalled()', function () {
+    $response = TransporterResponse::from(
+        fixture('OpenAI/chat-response'),
+        ['x-request-id' => '1']
+    );
+    $transport = Mockery::mock(TransporterContract::class);
+    $transport->allows()->requestObject(anyArgs())->andReturns($response);
+
+    $config = new OpenAIConfig();
+    $config->client = new Client($transport);
+    $chat = new OpenAIChat($config);
+
+    $response = $chat->generateText('here the question');
+    expect($chat->getTotalTokens())->toBe(21);
+
+    $response = $chat->generateTextOrReturnFunctionCalled('here the second question with function');
+    expect($chat->getTotalTokens())->toBe(42);
+});


### PR DESCRIPTION
This PR adds the possibility to store the last response from OpenAI to get advanced information like the token usage, fixing #109.

Here an example:
```php
$config = new OpenAIConfig();
$chat = new OpenAIChat($config);

$answer = $chat->generateText('here the question');
$response = $chat->getLastResponse();
printf("Tokens in prompt: %d\n", $response->usage->promptTokens);
printf("Tokens in response: %d\n", $response->usage->completionTokens);
printf("Total tokens: %d\n", $response->usage->totalTokens);
```
All the JSON properties from the OpenAI original HTTP response are available. Here an example of HTTP response (taken from the [original OpenAI documentation](https://platform.openai.com/docs/api-reference/chat/object)):

```json
{
    "id": "chatcmpl-123",
    "object": "chat.completion",
    "created": 1677652288,
    "model": "gpt-3.5-turbo-0125",
    "system_fingerprint": "fp_44709d6fcb",
    "choices": [{
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "\n\nHello there, how may I assist you today?"
      },
      "logprobs": null,
      "finish_reason": "stop"
    }],
    "usage": {
      "prompt_tokens": 9,
      "completion_tokens": 12,
      "total_tokens": 21
    }
}
```