### PR TITLE
Added retrieved documents in QuestionAnswering

### DIFF
--- a/src/Query/SemanticSearch/QuestionAnswering.php
+++ b/src/Query/SemanticSearch/QuestionAnswering.php
@@ -71,10 +71,9 @@ class QuestionAnswering
     private function searchDocumentAndCreateSystemMessage(string $question, int $k, array $additionalArguments): string
     {
         $embedding = $this->embeddingGenerator->embedText($question);
-        /** @var Document[] $documents */
         $this->retrievedDocs = $this->vectorStoreBase->similaritySearch($embedding, $k, $additionalArguments);
 
-        if (empty($this->retrievedDocs)) {
+        if ($this->retrievedDocs === []) {
             return "I don't know. I didn't find any document to answer the question";
         }
 

--- a/src/Query/SemanticSearch/QuestionAnswering.php
+++ b/src/Query/SemanticSearch/QuestionAnswering.php
@@ -11,6 +11,9 @@ use Psr\Http\Message\StreamInterface;
 
 class QuestionAnswering
 {
+    /** @var Document[] */
+    protected array $retrievedDocs;
+
     public string $systemMessageTemplate = "Use the following pieces of context to answer the question of the user. If you don't know the answer, just say that you don't know, don't try to make up an answer.\n\n{context}.";
 
     public function __construct(public readonly VectorStoreBase $vectorStoreBase, public readonly EmbeddingGeneratorInterface $embeddingGenerator, public readonly ChatInterface $chat)
@@ -55,20 +58,28 @@ class QuestionAnswering
     }
 
     /**
+     * @return Document[]
+     */
+    public function getRetrievedDocuments(): array
+    {
+        return $this->retrievedDocs;
+    }
+
+    /**
      * @param  array<string, string|int>|array<mixed[]>  $additionalArguments
      */
     private function searchDocumentAndCreateSystemMessage(string $question, int $k, array $additionalArguments): string
     {
         $embedding = $this->embeddingGenerator->embedText($question);
         /** @var Document[] $documents */
-        $documents = $this->vectorStoreBase->similaritySearch($embedding, $k, $additionalArguments);
+        $this->retrievedDocs = $this->vectorStoreBase->similaritySearch($embedding, $k, $additionalArguments);
 
-        if ($documents === []) {
+        if (empty($this->retrievedDocs)) {
             return "I don't know. I didn't find any document to answer the question";
         }
 
         $context = '';
-        foreach ($documents as $document) {
+        foreach ($this->retrievedDocs as $document) {
             $context .= $document->content.' ';
         }
 

--- a/tests/Unit/Query/SemanticSearch/QuestionAnsweringTest.php
+++ b/tests/Unit/Query/SemanticSearch/QuestionAnsweringTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Query\SemanticSearch;
+
+use LLPhant\Chat\ChatInterface;
+use LLPhant\Embeddings\Document;
+use LLPhant\Embeddings\EmbeddingGenerator\EmbeddingGeneratorInterface;
+use LLPhant\Embeddings\VectorStores\VectorStoreBase;
+use LLPhant\Query\SemanticSearch\QuestionAnswering;
+use Mockery;
+
+beforeEach(function () {
+    $this->question = 'What is the capital city of Italy?';
+    $this->answer = 'The capital city of Italy is Rome';
+
+    $this->docs = getDocuments();
+
+    $this->vectorStore = Mockery::mock(VectorStoreBase::class);
+    $this->vectorStore->allows([
+        'similaritySearch' => $this->docs,
+    ]);
+
+    $this->embedding = Mockery::mock(EmbeddingGeneratorInterface::class);
+    $this->embedding->allows([
+        'embedText' => [],
+    ]);
+
+    $this->chat = Mockery::mock(ChatInterface::class);
+    $this->chat->allows([
+        'setSystemMessage' => null,
+        'generateText' => $this->answer,
+    ]);
+});
+
+it('answer question', function () {
+
+    $qa = new QuestionAnswering($this->vectorStore, $this->embedding, $this->chat);
+
+    $result = $qa->answerQuestion($this->question);
+
+    expect($result)->toBe($this->answer);
+});
+
+it('retrieved Documents', function () {
+    $qa = new QuestionAnswering($this->vectorStore, $this->embedding, $this->chat);
+
+    $result = $qa->answerQuestion($this->question);
+    $docs = $qa->getRetrievedDocuments();
+
+    expect($docs)->toBe($this->docs);
+});
+
+/**
+ * @return Document[]
+ */
+function getDocuments(): array
+{
+    $doc1 = new Document;
+    $doc1->content = 'Rome is the capital city of Italy';
+    $doc2 = new Document;
+    $doc2->content = 'Rome is also the capital of the Lazio region';
+    $doc3 = new Document;
+    $doc3->content = 'The Metropolitan City of Rome, with a population of 4,355,725 residents';
+    $doc4 = new Document;
+    $doc4->content = 'Rome is often referred to as the City of Seven Hills due to its geographic location, and also as the "Eternal City"';
+
+    return [$doc1, $doc2, $doc3, $doc4];
+}


### PR DESCRIPTION
This PR adds the possibility to return the retrieved documents in `QuestionAnswering` using the similarity search in `searchDocumentAndCreateSystemMessage()`. This can be useful when implementing RAG architectures to retrieve the documents (chunk) used to generate the answer.

I proposed to add a `QuestionAnswering::getRetrievedDocuments()` that returns the array of Documents retrieved from the similarity search, as follows:

```php
$qa = new QuestionAnswering($vectorStore, $embedding, $chat);

$result = $qa->answerQuestion('What is the capital city of Italy?');
print($result); // The capital city of Italy is Rome

$docs = $qa->getRetrievedDocuments();
printf("Answer generated using the following contents:\n");
foreach($docs as $d) {
    printf("%s\n", $d->content);
    printf("Source: %s\n", $d->sourceName);
}
```