### PR TITLE
fix #100 update deprecated constants in doctrine

### DIFF
--- a/src/Embeddings/VectorStores/Doctrine/PgVectorL2OperatorDql.php
+++ b/src/Embeddings/VectorStores/Doctrine/PgVectorL2OperatorDql.php
@@ -4,9 +4,9 @@ namespace LLPhant\Embeddings\VectorStores\Doctrine;
 
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
-use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
+use Doctrine\ORM\Query\TokenType;
 
 /**
  * L2DistanceFunction ::=
@@ -20,16 +20,16 @@ final class PgVectorL2OperatorDql extends FunctionNode
 
     public function parse(Parser $parser): void
     {
-        $parser->match(Lexer::T_IDENTIFIER);
-        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $parser->match(TokenType::T_IDENTIFIER);
+        $parser->match(TokenType::T_OPEN_PARENTHESIS);
 
         $this->vectorOne = $parser->ArithmeticFactor(); // Fix that, should be vector
 
-        $parser->match(Lexer::T_COMMA);
+        $parser->match(TokenType::T_COMMA);
 
         $this->vectorTwo = $parser->ArithmeticFactor(); // Fix that, should be vector
 
-        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+        $parser->match(TokenType::T_CLOSE_PARENTHESIS);
     }
 
     public function getSql(SqlWalker $sqlWalker): string


### PR DESCRIPTION
fix #100 deprecated constant Lexer for TokenType constant in doctrine/orm 2.19 see [here](https://github.com/doctrine/orm/commit/5049b615c510bb9c5bcc62df92c6fc622cb7fb57)