### PR TITLE
Notion reader #5 - Part 1

### DIFF
--- a/src/Embeddings/DataReader/FileDataReader.php
+++ b/src/Embeddings/DataReader/FileDataReader.php
@@ -2,7 +2,6 @@
 
 namespace LLPhant\Embeddings\DataReader;
 
-use Exception;
 use LLPhant\Embeddings\Document;
 use PhpOffice\PhpWord\Element\Section;
 use PhpOffice\PhpWord\Element\Text;
@@ -18,7 +17,7 @@ final class FileDataReader implements DataReader
      * @template T of Document
      *
      * @param  class-string<T>  $documentClassName
-     * @param string[] $extensions
+     * @param  string[]  $extensions
      */
     public function __construct(public string $filePath, public readonly string $documentClassName = Document::class, private readonly array $extensions = [])
     {
@@ -49,14 +48,14 @@ final class FileDataReader implements DataReader
     /**
      * @return Document[]
      */
-    private function getDocumentsFromDirectory(string $path): array
+    private function getDocumentsFromDirectory(string $directory): array
     {
         $documents = [];
         // Open the directory
-        if ($handle = opendir($path)) {
+        if ($handle = opendir($directory)) {
             // Read the directory contents
             while (($entry = readdir($handle)) !== false) {
-                $fullPath = $path . '/' . $entry;
+                $fullPath = $directory.'/'.$entry;
                 if ($entry != '.' && $entry != '..') {
                     if (is_dir($fullPath)) {
                         $documents = [...$documents, ...$this->getDocumentsFromDirectory($fullPath)];
@@ -80,7 +79,7 @@ final class FileDataReader implements DataReader
     {
         $fileExtension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
 
-        if (!$this->validExtension($fileExtension)) {
+        if (! $this->validExtension($fileExtension)) {
             return false;
         }
 
@@ -131,7 +130,7 @@ final class FileDataReader implements DataReader
 
     private function validExtension(string $fileExtension): bool
     {
-        if (sizeof($this->extensions) === 0) {
+        if ($this->extensions === []) {
             return true;
         }
 

--- a/src/Embeddings/DataReader/FileDataReader.php
+++ b/src/Embeddings/DataReader/FileDataReader.php
@@ -43,11 +43,7 @@ final class FileDataReader implements DataReader
                     if ($entry != '.' && $entry != '..' && is_file($fullPath)) {
                         $content = $this->getContentFromFile($fullPath);
                         if ($content !== false) {
-                            $document = new $this->documentClassName();
-                            $document->content = $content;
-                            $document->sourceType = $this->sourceType;
-                            $document->sourceName = $entry;
-                            $documents[] = $document;
+                            $documents[] = $this->getDocument($content, $entry);
                         }
                     }
                 }
@@ -63,12 +59,8 @@ final class FileDataReader implements DataReader
         if ($content === false) {
             return [];
         }
-        $document = new $this->documentClassName();
-        $document->content = $content;
-        $document->sourceType = $this->sourceType;
-        $document->sourceName = $this->filePath;
 
-        return [$document];
+        return [$this->getDocument($content, $this->filePath)];
     }
 
     /**
@@ -109,5 +101,15 @@ final class FileDataReader implements DataReader
         }
 
         return $text;
+    }
+
+    private function getDocument(string $content, string $entry): mixed
+    {
+        $document = new $this->documentClassName();
+        $document->content = $content;
+        $document->sourceType = $this->sourceType;
+        $document->sourceName = $entry;
+
+        return $document;
     }
 }

--- a/src/Embeddings/DataReader/FileDataReader.php
+++ b/src/Embeddings/DataReader/FileDataReader.php
@@ -33,21 +33,12 @@ final class FileDataReader implements DataReader
             return [];
         }
 
-        return $this->getDocumentsFrom($this->filePath);
-    }
-
-    /**
-     * @return Document[]
-     * @throws Exception
-     */
-    private function getDocumentsFrom(string $path): array
-    {
         // If it's a directory
-        if (is_dir($path)) {
-            return $this->getContentFromDirectory($path);
+        if (is_dir($this->filePath)) {
+            return $this->getDocumentsFromDirectory($this->filePath);
         }
         // If it's a file
-        $content = $this->getContentFromFile($path);
+        $content = $this->getContentFromFile($this->filePath);
         if ($content === false) {
             return [];
         }
@@ -57,9 +48,8 @@ final class FileDataReader implements DataReader
 
     /**
      * @return Document[]
-     * @throws Exception
      */
-    private function getContentFromDirectory(string $path): array
+    private function getDocumentsFromDirectory(string $path): array
     {
         $documents = [];
         // Open the directory
@@ -69,7 +59,7 @@ final class FileDataReader implements DataReader
                 $fullPath = $path . '/' . $entry;
                 if ($entry != '.' && $entry != '..') {
                     if (is_dir($fullPath)) {
-                        $documents = [...$documents, ...$this->getDocumentsFrom($fullPath)];
+                        $documents = [...$documents, ...$this->getDocumentsFromDirectory($fullPath)];
                     } else {
                         $content = $this->getContentFromFile($fullPath);
                         if ($content !== false) {
@@ -86,9 +76,6 @@ final class FileDataReader implements DataReader
         return $documents;
     }
 
-    /**
-     * @throws Exception
-     */
     private function getContentFromFile(string $path): string|false
     {
         $fileExtension = strtolower(pathinfo($path, PATHINFO_EXTENSION));

--- a/tests/Unit/Embeddings/DataReader/FileDataReaderTest.php
+++ b/tests/Unit/Embeddings/DataReader/FileDataReaderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Embeddings\DataReader;
 
 use LLPhant\Embeddings\DataReader\FileDataReader;
+use LLPhant\Embeddings\Document;
 
 it('read one specific file', function () {
     $filePath = __DIR__.'/FilesTestDirectory/hello.txt';
@@ -49,3 +50,23 @@ it('can read pdf and texts ', function () {
     expect($foundPDF)->toBeTrue();
     expect($foundText)->toBeTrue();
 });
+
+
+it('can filter files based on extensions', function () {
+    $filePath = __DIR__.'/FilesTestDirectory/';
+    $reader = new FileDataReader($filePath, Document::class, ['docx']);
+    $documents = $reader->getDocuments();
+
+    expect($documents)->toHaveCount(1);
+});
+
+it('can read sub-directories', function () {
+    $filePath = __DIR__.'/FilesTestDirectory/';
+    $reader = new FileDataReader($filePath, Document::class, ['txt']);
+    $documents = $reader->getDocuments();
+
+    $contents = array_map(fn($doc) => $doc->content, $documents);
+
+    expect($contents)->toContain("hello test!\n", "hello test2!\n", "hello test3!\n");
+});
+

--- a/tests/Unit/Embeddings/DataReader/FileDataReaderTest.php
+++ b/tests/Unit/Embeddings/DataReader/FileDataReaderTest.php
@@ -51,7 +51,6 @@ it('can read pdf and texts ', function () {
     expect($foundText)->toBeTrue();
 });
 
-
 it('can filter files based on extensions', function () {
     $filePath = __DIR__.'/FilesTestDirectory/';
     $reader = new FileDataReader($filePath, Document::class, ['docx']);
@@ -65,8 +64,7 @@ it('can read sub-directories', function () {
     $reader = new FileDataReader($filePath, Document::class, ['txt']);
     $documents = $reader->getDocuments();
 
-    $contents = array_map(fn($doc) => $doc->content, $documents);
+    $contents = array_map(fn ($doc) => $doc->content, $documents);
 
     expect($contents)->toContain("hello test!\n", "hello test2!\n", "hello test3!\n");
 });
-

--- a/tests/Unit/Embeddings/DataReader/FilesTestDirectory/TestSubDirectory/hello3.txt
+++ b/tests/Unit/Embeddings/DataReader/FilesTestDirectory/TestSubDirectory/hello3.txt
@@ -1,0 +1,1 @@
+hello test3!


### PR DESCRIPTION
This is the first part of a change to address #5 
Here I introduced two changes to `FileDataReader`
* it is now possible to filter files to read based on extensions
* the reader reads also file in subdirectories.

These changes are intended as a basis for creating a Notion Data Reader that filters files of type `md` and `csv` and that are present in subdirectories. This is because exporting data from Notion creates such a structure.

Please let me know if I am going in the right direction or if I have misunderstood something.