### PR TITLE
Improve integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,8 @@ as in the `docker-compose.yaml` file from `devx` folder.
 Then run this sql query to create the table for the tests:
 
 ```postgresql
+CREATE EXTENSION vector;
+
 CREATE TABLE IF NOT EXISTS test_place (
                                           id SERIAL PRIMARY KEY,
                                           content text,
@@ -81,7 +83,19 @@ CREATE TABLE IF NOT EXISTS test_place (
                                           sourcetype text,
                                           sourcename text,
                                           embedding vector
-)
+);
+```
 
+Then run:
+```bash
+composer test:int
+```
+
+You can set host names for the various services involved in integration tests using these environment variables:
+```
+PGVECTOR_HOST
+ELASTIC_URL
+MILVUS_HOST
+REDIS_HOST
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "phpstan/phpstan": "^1.10.25",
         "predis/predis": "^2.2",
         "rector/rector": "^0.16.0",
+        "symfony/cache": "^7.0",
         "symfony/var-dumper": "^6.3.1 || ^7.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "suggest": {
         "doctrine/orm": "This is required for the DoctrineVectoreStore. This should be working with any version ^2.13.0",
+        "symfony/cache": "This is one of the possible types of psr/cache needed by doctrine/orm",
         "hkulekci/qdrant": "This is required for the QdrantVectoreStore.",
         "predis/predis": "This is required for the RedisVectoreStore.",
         "elasticsearch/elasticsearch": "This is required for the ElasticsearchVectoreStore."

--- a/devx/docker-compose-pgvector.yml
+++ b/devx/docker-compose-pgvector.yml
@@ -5,11 +5,13 @@ services:
     # In production, you may want to use a managed database service
     image: ankane/pgvector
     environment:
-      - POSTGRES_DB=api
+      - POSTGRES_DB=postgres
       - POSTGRES_USER=myuser
       # You should definitely change the password in production
       - POSTGRES_PASSWORD=!ChangeMe!
     volumes:
+      # This script initialises the DB for integration tests
+      - ./pgvector/scripts:/docker-entrypoint-initdb.d
       - db-data:/var/lib/postgresql/data:rw
       # You may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!
       # - ./docker/db/data:/var/lib/postgresql/data:rw

--- a/devx/pgvector/scripts/01.sql
+++ b/devx/pgvector/scripts/01.sql
@@ -1,0 +1,10 @@
+CREATE EXTENSION vector;
+
+CREATE TABLE IF NOT EXISTS test_place (
+                                          id SERIAL PRIMARY KEY,
+                                          content text,
+                                          type text,
+                                          sourcetype text,
+                                          sourcename text,
+                                          embedding vector
+);

--- a/tests/Integration/Embeddings/VectorStores/Doctrine/DoctrineVectorStoreTest.php
+++ b/tests/Integration/Embeddings/VectorStores/Doctrine/DoctrineVectorStoreTest.php
@@ -23,7 +23,7 @@ it('creates two entity with their embeddings and perform a similarity search', f
         'dbname' => 'postgres',
         'user' => 'myuser',
         'password' => '!ChangeMe!',
-        'host' => 'localhost',
+        'host' => getenv('PGVECTOR_HOST') ?? 'localhost',
         'driver' => 'pdo_pgsql',
     ];
 
@@ -63,7 +63,7 @@ it('tests a full embedding flow with Doctrine', function () {
         'dbname' => 'postgres',
         'user' => 'myuser',
         'password' => '!ChangeMe!',
-        'host' => 'localhost',
+        'host' => getenv('PGVECTOR_HOST') ?? 'localhost',
         'driver' => 'pdo_pgsql',
     ];
 

--- a/tests/Integration/Embeddings/VectorStores/Elasticsearch/ElasticsearchVectorStoreTest.php
+++ b/tests/Integration/Embeddings/VectorStores/Elasticsearch/ElasticsearchVectorStoreTest.php
@@ -27,7 +27,7 @@ it('tests a full embedding flow with Elasticsearch', function () {
     $embeddingQuery = json_decode($rawFileContent, true);
 
     $client = (new ClientBuilder())::create()
-        ->setHosts([getenv('ELASTIC_URL') ?? 'http://elasticsearch:9200'])
+        ->setHosts([getenv('ELASTIC_URL') ?? 'http://localhost:9200'])
         ->build();
     $vectorStore = new ElasticsearchVectorStore($client, 'llphant_test');
 

--- a/tests/Integration/Embeddings/VectorStores/Elasticsearch/ElasticsearchVectorStoreTest.php
+++ b/tests/Integration/Embeddings/VectorStores/Elasticsearch/ElasticsearchVectorStoreTest.php
@@ -27,7 +27,7 @@ it('tests a full embedding flow with Elasticsearch', function () {
     $embeddingQuery = json_decode($rawFileContent, true);
 
     $client = (new ClientBuilder())::create()
-        ->setHosts(['http://localhost:9200'])
+        ->setHosts([getenv('ELASTIC_URL') ?? 'http://elasticsearch:9200'])
         ->build();
     $vectorStore = new ElasticsearchVectorStore($client, 'llphant_test');
 

--- a/tests/Integration/Embeddings/VectorStores/Milvus/MilvusVectorStoreTest.php
+++ b/tests/Integration/Embeddings/VectorStores/Milvus/MilvusVectorStoreTest.php
@@ -26,7 +26,7 @@ it('tests a full embedding flow with Milvus', function () {
     /** @var float[] $embeddingQuery */
     $embeddingQuery = json_decode($rawFileContent, true);
 
-    $client = new MilvusClient('localhost', '19530', 'root', 'milvus');
+    $client = new MilvusClient(getenv('MILVUS_HOST') ?? 'localhost', '19530', 'root', 'milvus');
     $vectorStore = new MilvusVectorStore($client);
 
     $vectorStore->addDocuments($embeddedDocuments);

--- a/tests/Integration/Embeddings/VectorStores/Redis/RedisVectorStoreTest.php
+++ b/tests/Integration/Embeddings/VectorStores/Redis/RedisVectorStoreTest.php
@@ -30,7 +30,7 @@ it('tests a full embedding flow with Redis', function () {
 
     $redisClient = new Client([
         'scheme' => 'tcp',
-        'host' => 'localhost',
+        'host' => getenv('REDIS_HOST') ?? 'localhost',
         'port' => 6379,
     ]);
     $vectorStore = new RedisVectorStore($redisClient);


### PR DESCRIPTION
I made some notes on the integration tests, including adding a script to initialize PGVector's test DB and some environment variables to increase the flexibility of the configuration, such as making it possible to run PHP inside a container spinned up with DB containers.