### PR TITLE
Update QdrantVectorStore.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "doctrine/orm": "^2.13.0",
         "elasticsearch/elasticsearch": "^8.10",
-        "hkulekci/qdrant": "^v0.4",
+        "hkulekci/qdrant": "^v0.5.3",
         "laravel/pint": "^v1.13.7",
         "mockery/mockery": "^1.6",
         "pestphp/pest": "2.32.0",

--- a/src/Embeddings/VectorStores/Qdrant/QdrantVectorStore.php
+++ b/src/Embeddings/VectorStores/Qdrant/QdrantVectorStore.php
@@ -3,11 +3,12 @@
 namespace LLPhant\Embeddings\VectorStores\Qdrant;
 
 use Exception;
+use GuzzleHttp\Client;
 use LLPhant\Embeddings\Document;
 use LLPhant\Embeddings\DocumentUtils;
 use LLPhant\Embeddings\VectorStores\VectorStoreBase;
 use Qdrant\Config;
-use Qdrant\Http\GuzzleClient;
+use Qdrant\Http\Transport;
 use Qdrant\Models\Filter\Condition\ConditionInterface;
 use Qdrant\Models\Filter\Filter;
 use Qdrant\Models\PointsStruct;
@@ -27,7 +28,7 @@ class QdrantVectorStore extends VectorStoreBase
 
     public function __construct(Config $config, private string $collectionName)
     {
-        $this->client = new Qdrant(new GuzzleClient($config));
+        $this->client = new Qdrant(new Transport(new Client(), $config));
     }
 
     /**


### PR DESCRIPTION
Fixing Qdrant implementation, the GuzzleClient class was removed in the v0.5.3 version: https://github.com/hkulekci/qdrant-php/commit/f4586178cd5593ce91654f8744e3053ccae668d9