### PR TITLE
Add 0.9.2 version for openai-php/client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "guzzlehttp/guzzle": "^7.1.0",
         "guzzlehttp/psr7": "^2.6",
         "nunomaduro/termwind": "^1.15 || ^2.0",
-        "openai-php/client": "^v0.7.7 || ^v0.8.4",
+        "openai-php/client": "^v0.7.7 || ^v0.8.4 || ^v0.9.2",
         "phpoffice/phpword": "^1.1",
         "psr/http-message": "^2.0",
         "smalot/pdfparser": "^2.7"

--- a/tests/Unit/Chat/MockOpenAIClient.php
+++ b/tests/Unit/Chat/MockOpenAIClient.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Chat;
 use OpenAI\Contracts\ClientContract;
 use OpenAI\Contracts\Resources\AssistantsContract;
 use OpenAI\Contracts\Resources\AudioContract;
+use OpenAI\Contracts\Resources\BatchesContract;
 use OpenAI\Contracts\Resources\ChatContract;
 use OpenAI\Contracts\Resources\CompletionsContract;
 use OpenAI\Contracts\Resources\EditsContract;
@@ -82,5 +83,10 @@ class MockOpenAIClient implements ClientContract
     public function threads(): ThreadsContract
     {
         // TODO: Implement threads() method.
+    }
+
+    public function batches(): BatchesContract
+    {
+        // TODO: Implement batches() method.
     }
 }


### PR DESCRIPTION
openai-php/client from version 0.9.0 supports usage statistics for streaming in the Chat Completions 
https://github.com/openai-php/client/issues/386