### PR TITLE
Fix error in example with TaskManager.php

### DIFF
--- a/src/Experimental/Agent/TaskManager.php
+++ b/src/Experimental/Agent/TaskManager.php
@@ -18,6 +18,12 @@ class TaskManager
             if (! is_array($task)) {
                 continue;
             }
+            if (! array_key_exists('name', $task)) {
+                continue;
+            }
+            if (! array_key_exists('description', $task)) {
+                continue;
+            }
             $tasksObject[] = new Task($task['name'], $task['description']);
         }
 

--- a/tests/Unit/Experimental/Agent/TaskManagerTest.php
+++ b/tests/Unit/Experimental/Agent/TaskManagerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\Experimental\Agent;
+
+use LLPhant\Experimental\Agent\TaskManager;
+
+it('does not crash with wrong parameter array', function () {
+    $taksManager = new TaskManager();
+
+    $taksManager->addTasks([['foo' => 'bar']]);
+
+    expect($taksManager->tasks)->toBeEmpty();
+});
+
+it('works with correct parameter array', function () {
+    $taksManager = new TaskManager();
+
+    $taksManager->addTasks([['name' => 'foo', 'description' => 'bar']]);
+
+    expect($taksManager->tasks)->toHaveCount(1);
+    $task = $taksManager->tasks[0];
+    expect($task->name)->toBe('foo')->and($task->description)->toBe('bar');
+});


### PR DESCRIPTION
Running `examples/get-web-page-autoPHP/script.php` from time to time we can get this error:
```
Warning: Undefined array key "description" in /var/llphant/examples/get-web-page-autoPHP/vendor/theodo-group/llphant/src/Experimental/Agent/TaskManager.php on line 21

Fatal error: Uncaught TypeError: LLPhant\Experimental\Agent\Task::__construct(): Argument #2 ($description) must be of type string, null given, called in /var/llphant/examples/get-web-page-autoPHP/vendor/theodo-group/llphant/src/Experimental/Agent/TaskManager.php on line 21 and defined in /var/llphant/examples/get-web-page-autoPHP/vendor/theodo-group/llphant/src/Experimental/Agent/Task.php:11
Stack trace:
#0 /var/llphant/examples/get-web-page-autoPHP/vendor/theodo-group/llphant/src/Experimental/Agent/TaskManager.php(21): LLPhant\Experimental\Agent\Task->__construct('Document Source...', NULL)
#1 /var/llphant/examples/get-web-page-autoPHP/vendor/theodo-group/llphant/src/Chat/OpenAIChat.php(333): LLPhant\Experimental\Agent\TaskManager->addTasks(Array)
#2 /var/llphant/examples/get-web-page-autoPHP/vendor/theodo-group/llphant/src/Chat/OpenAIChat.php(290): LLPhant\Chat\OpenAIChat->callFunction('addTasks', Array)
#3 /var/llphant/examples/get-web-page-autoPHP/vendor/theodo-group/llphant/src/Chat/OpenAIChat.php(64): LLPhant\Chat\OpenAIChat->handleTools(Object(OpenAI\Responses\Chat\CreateResponse))
#4 /var/llphant/examples/get-web-page-autoPHP/vendor/theodo-group/llphant/src/Experimental/Agent/CreationTaskAgent.php(62): LLPhant\Chat\OpenAIChat->generateText('You are a task ...')
#5 /var/llphant/examples/get-web-page-autoPHP/vendor/theodo-group/llphant/src/Experimental/Agent/AutoPHP.php(48): LLPhant\Experimental\Agent\CreationTaskAgent->createTasks('Find the name o...', Array)
#6 /var/llphant/examples/get-web-page-autoPHP/script.php(17): LLPhant\Experimental\Agent\AutoPHP->run()
#7 {main}
  thrown in /var/llphant/examples/get-web-page-autoPHP/vendor/theodo-group/llphant/src/Experimental/Agent/Task.php on line 11
```