### PR TITLE
FunctionBuilder::buildFunctionInfo() Added extraction of parameters descriptions from phpDoc

### DIFF
--- a/src/Chat/FunctionInfo/FunctionBuilder.php
+++ b/src/Chat/FunctionInfo/FunctionBuilder.php
@@ -12,7 +12,7 @@ class FunctionBuilder
         $reflection = new ReflectionMethod($instance::class, $name);
         $docComment = $reflection->getDocComment() ?: '';
         $params = $reflection->getParameters();
-        
+
         $parametersDescriptions = [];
         preg_match_all('/@param\s+\w+\s+\$(\w+)\s+(.+)/', $docComment, $matches, PREG_SET_ORDER);
         foreach ($matches as $match) {

--- a/src/Chat/FunctionInfo/FunctionBuilder.php
+++ b/src/Chat/FunctionInfo/FunctionBuilder.php
@@ -28,6 +28,7 @@ class FunctionBuilder
             /** @var ReflectionNamedType $reflectionType */
             $reflectionType = $param->getType();
 
+            $parameterName = $param->getName();
             $newParameter = new Parameter($parameterName, TypeMapper::mapPhpTypeToJsonSchemaType($reflectionType), $parametersDescriptions[$parameterName] ?? '');
 
             if ($newParameter->type === 'array') {

--- a/src/Chat/FunctionInfo/FunctionBuilder.php
+++ b/src/Chat/FunctionInfo/FunctionBuilder.php
@@ -40,7 +40,6 @@ class FunctionBuilder
             }
         }
 
-        $docComment = $reflection->getDocComment() ?: '';
         // Remove PHPDoc annotations and get only the description
         $functionDescription = preg_replace('/\s*\* @.*/', '', $docComment);
         $functionDescription = trim(str_replace(['/**', '*/', '*'], '', $functionDescription ?? ''));

--- a/src/Chat/FunctionInfo/FunctionBuilder.php
+++ b/src/Chat/FunctionInfo/FunctionBuilder.php
@@ -14,7 +14,7 @@ class FunctionBuilder
         $params = $reflection->getParameters();
 
         $parametersDescriptions = [];
-        preg_match_all('/@param\s+\w+\s+\$(\w+)\s+(.+)/', $docComment, $matches, PREG_SET_ORDER);
+        preg_match_all('/@param.+?\$(\w+)\s+(.+)/', $docComment, $matches, PREG_SET_ORDER);
         foreach ($matches as $match) {
             $paramName = $match[1];
             $paramDescription = trim($match[2]);

--- a/tests/Unit/Chat/Function/FunctionBuilderTest.php
+++ b/tests/Unit/Chat/Function/FunctionBuilderTest.php
@@ -7,11 +7,46 @@ namespace Tests\Unit\Chat\Function;
 use LLPhant\Chat\FunctionInfo\FunctionBuilder;
 
 it('creates a functionInfo instance from a random class method', function () {
-
     $functionInfo = FunctionBuilder::buildFunctionInfo(new RichExample(), 'example');
 
     expect($functionInfo->name)->toBe('example');
     expect($functionInfo->description)->toBe('This is the description of the example function from the RichExample class.');
     expect($functionInfo->parameters[0]->name)->toBe('stringVar');
     expect($functionInfo->parameters[0]->type)->toBe('string');
+});
+
+it('creates a functionInfo instance from a method with complete docblock', function () {
+    $functionInfo = FunctionBuilder::buildFunctionInfo(new RichExample(), 'example');
+
+    expect($functionInfo->name)->toBe('example');
+    expect($functionInfo->description)->toBe('This is the description of the example function from the RichExample class.');
+    expect($functionInfo->parameters)->toHaveCount(5);
+
+    expect($functionInfo->parameters[0]->description)->toBe('This is the description of the stringVar parameter.');
+    expect($functionInfo->parameters[1]->description)->toBe('This is the description of the intVar parameter.');
+    expect($functionInfo->parameters[2]->description)->toBe('This is the description of the floatVar parameter.');
+    expect($functionInfo->parameters[3]->description)->toBe('This is the description of the boolVar parameter.');
+    expect($functionInfo->parameters[4]->description)->toBe('This is the description of the arrayVar parameter.');
+});
+
+it('creates a functionInfo instance from a method without parameters in docblock', function () {
+    $functionInfo = FunctionBuilder::buildFunctionInfo(new RichExample(), 'exampleWithNoPhpDocForParameters');
+
+    expect($functionInfo->name)->toBe('exampleWithNoPhpDocForParameters');
+    expect($functionInfo->description)->toBe('This is the description of the example function from the RichExample class.');
+    expect($functionInfo->parameters)->toHaveCount(5);
+
+    expect($functionInfo->parameters[0]->description)->toBe('');
+    expect($functionInfo->parameters[1]->description)->toBe('');
+    expect($functionInfo->parameters[2]->description)->toBe('');
+    expect($functionInfo->parameters[3]->description)->toBe('');
+    expect($functionInfo->parameters[4]->description)->toBe('');
+});
+
+it('handles functions without parameters', function () {
+    $functionInfo = FunctionBuilder::buildFunctionInfo(new RichExample(), 'exampleWithNoParametersAndNoPhpdoc');
+
+    expect($functionInfo->name)->toBe('exampleWithNoParametersAndNoPhpdoc');
+    expect($functionInfo->description)->toBe('');
+    expect($functionInfo->parameters)->toBeEmpty();
 });

--- a/tests/Unit/Chat/Function/RichExample.php
+++ b/tests/Unit/Chat/Function/RichExample.php
@@ -19,4 +19,17 @@ class RichExample
     {
         var_dump($stringVar, $intVar, $floatVar, $boolVar, $arrayVar);
     }
+
+    /**
+     * This is the description of the example function from the RichExample class.
+     */
+    public function exampleWithNoPhpDocForParameters(string $stringVar, int $intVar, float $floatVar, bool $boolVar, array $arrayVar): void
+    {
+        var_dump($stringVar, $intVar, $floatVar, $boolVar, $arrayVar);
+    }
+
+    public function exampleWithNoParametersAndNoPhpdoc(): void
+    {
+        echo "test";
+    }
 }

--- a/tests/Unit/Chat/Function/RichExample.php
+++ b/tests/Unit/Chat/Function/RichExample.php
@@ -30,6 +30,6 @@ class RichExample
 
     public function exampleWithNoParametersAndNoPhpdoc(): void
     {
-        echo "test";
+        echo 'test';
     }
 }


### PR DESCRIPTION
At the moment FunctionBuilder::buildFunctionInfo() always returns an empty description for every parameter.

This PR extract the descriptions from phpDoc.

Fixes https://github.com/theodo-group/LLPhant/issues/171