### PR TITLE
🐛✅ Bugfix: don't throw away "0" string when creating streamed response

### DIFF
--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -237,7 +237,11 @@ class OpenAIChat implements ChatInterface
                     break;
                 }
 
-                if (! ($partialResponse->choices[0]->delta->content)) {
+                if ($partialResponse->choices[0]->delta->content === null) {
+                    continue;
+                }
+
+                if ($partialResponse->choices[0]->delta->content === '') {
                     continue;
                 }
 


### PR DESCRIPTION
I had a bug where my response often got cut off, and instead of returning the year "2020" in the response, it would always return "202".

I found out that it only happens when streaming the response.

After looking around I found the issue to be inside of the `OpenAIChat::createStreamedResponse()` method.  There is a check there like this: `if (! ($partialResponse->choices[0]->delta->content)) { continue; }` but if the string is "0" then this also evaluates to `true` causing the "0" to be ignored when it's the only character in the partial response.

I changed this to explicity check whether the content is `null` or `''` instead. I also added a test to validate that "0" is not thrown away anymore.