### PR TITLE
✨✅ Allow word overlap when splitting documents

### DIFF
--- a/src/Embeddings/DocumentSplitter/DocumentSplitter.php
+++ b/src/Embeddings/DocumentSplitter/DocumentSplitter.php
@@ -9,7 +9,7 @@ final class DocumentSplitter
     /**
      * @return Document[]
      */
-    public static function splitDocument(Document $document, int $maxLength = 1000, string $separator = ' '): array
+    public static function splitDocument(Document $document, int $maxLength = 1000, string $separator = ' ', int $wordOverlap = 0): array
     {
         $text = $document->content;
         if (empty($text)) {
@@ -29,24 +29,16 @@ final class DocumentSplitter
 
         $chunks = [];
         $words = explode($separator, $text);
-        $currentChunk = '';
-
-        foreach ($words as $word) {
-            if (strlen($currentChunk.$separator.$word) <= $maxLength || empty($currentChunk)) {
-                if (empty($currentChunk)) {
-                    $currentChunk = $word;
-                } else {
-                    $currentChunk .= $separator.$word;
-                }
-            } else {
-                $chunks[] = trim($currentChunk);
-                $currentChunk = $word;
-            }
+        if ($wordOverlap > 0) {
+            $chunks = self::createChunksWithOverlap($words, $maxLength, $separator, $wordOverlap);
+        } else {
+            // This method is not really necessary anymore.
+            // The new `createChunksWithOverlap` method handles this too.
+            // But to prevent possible bugs when introducing the new method,
+            // We will handle this case with the old method for now.
+            $chunks = self::createChunksWithoutOverlap($words, $maxLength, $separator);
         }
 
-        if (! empty($currentChunk)) {
-            $chunks[] = trim($currentChunk);
-        }
         $splittedDocuments = [];
         $chunkNumber = 0;
         foreach ($chunks as $chunk) {
@@ -68,13 +60,88 @@ final class DocumentSplitter
      * @param  Document[]  $documents
      * @return Document[]
      */
-    public static function splitDocuments(array $documents, int $maxLength = 1000, string $separator = '.'): array
+    public static function splitDocuments(array $documents, int $maxLength = 1000, string $separator = '.', int $wordOverlap = 0): array
     {
         $splittedDocuments = [];
         foreach ($documents as $document) {
-            $splittedDocuments = array_merge($splittedDocuments, DocumentSplitter::splitDocument($document, $maxLength, $separator));
+            $splittedDocuments = array_merge($splittedDocuments, DocumentSplitter::splitDocument($document, $maxLength, $separator, $wordOverlap));
         }
 
         return $splittedDocuments;
+    }
+
+    /**
+     * @param  array<string>  $words
+     * @return array<string>
+     */
+    private static function createChunksWithoutOverlap(array $words, int $maxLength, string $separator): array
+    {
+        $chunks = [];
+        $currentChunk = '';
+        foreach ($words as $word) {
+            if (strlen($currentChunk.$separator.$word) <= $maxLength || empty($currentChunk)) {
+                if (empty($currentChunk)) {
+                    $currentChunk = $word;
+                } else {
+                    $currentChunk .= $separator.$word;
+                }
+            } else {
+                $chunks[] = trim($currentChunk);
+                $currentChunk = $word;
+            }
+        }
+
+        if (! empty($currentChunk)) {
+            $chunks[] = trim($currentChunk);
+        }
+
+        return $chunks;
+    }
+
+    /**
+     * @param  array<string>  $words
+     * @return array<string>
+     */
+    private static function createChunksWithOverlap(array $words, int $maxLength, string $separator, int $wordOverlap): array
+    {
+        $chunks = [];
+        $currentChunk = [];
+        $currentChunkLength = 0;
+        foreach ($words as $word) {
+            if ($word === '') {
+                continue;
+            }
+
+            if ($currentChunkLength + strlen($separator.$word) <= $maxLength || $currentChunk === []) {
+                $currentChunk[] = $word;
+                $currentChunkLength = self::calcChunkLength($currentChunk, $separator);
+            } else {
+                // Add the chunk with overlap
+                $chunks[] = implode($separator, $currentChunk);
+
+                // Calculate overlap words
+                $calculatedOverlap = min($wordOverlap, count($currentChunk) - 1);
+                $overlapWords = $calculatedOverlap > 0 ? array_slice($currentChunk, -$calculatedOverlap) : [];
+
+                // Start a new chunk with overlap words
+                $currentChunk = [...$overlapWords, $word];
+                $currentChunk[0] = trim($currentChunk[0]);
+                $currentChunkLength = self::calcChunkLength($currentChunk, $separator);
+            }
+        }
+
+        if ($currentChunk !== []) {
+            $chunks[] = implode($separator, $currentChunk);
+        }
+
+        return $chunks;
+    }
+
+    /**
+     * @param  array<string>  $currentChunk
+     */
+    private static function calcChunkLength(array $currentChunk, string $separator): int
+    {
+        return array_sum(array_map('strlen', $currentChunk)) + count($currentChunk) * strlen($separator) - 1;
     }
 }

--- a/tests/Unit/Embeddings/DocumentSplitter/DocumentSplitterTest.php
+++ b/tests/Unit/Embeddings/DocumentSplitter/DocumentSplitterTest.php
@@ -55,3 +55,58 @@ The house is on fire';
     $result = DocumentSplitter::splitDocument($document1, 100, "\n");
     expect($result[0]->content)->toBe('Burritos are cool');
 });
+
+it('adds overlap when splitting documents', function () {
+    $document = new Document();
+    $document->content = 'This is a test with one overlapping word';
+    $result = DocumentSplitter::splitDocument($document, 20, ' ', 1);
+    expect($result[0]->content)->toBe('This is a test with');
+    expect($result[1]->content)->toBe('with one overlapping');
+    expect($result[2]->content)->toBe('overlapping word');
+
+    $document = new Document();
+    $document->content = 'This is a test with two overlapping words';
+    $result = DocumentSplitter::splitDocument($document, 20, ' ', 2);
+    expect($result[0]->content)->toBe('This is a test with');
+    expect($result[1]->content)->toBe('test with two');
+    expect($result[2]->content)->toBe('with two overlapping');
+    expect($result[3]->content)->toBe('two overlapping words');
+});
+
+it('adds overlap when splitting multiple documents', function () {
+    $document1 = new Document();
+    $document1->content = 'This. Is. A. Test. With. Overlapping. Words.';
+    $document2 = new Document();
+    $document2->content = 'Another. Test. With. Overlapping. Words.';
+    $result = DocumentSplitter::splitDocuments([$document1, $document2], 20, '.', 1);
+    expect($result[0]->content)->toBe('This. Is. A. Test');
+    expect($result[1]->content)->toBe('Test. With');
+    expect($result[2]->content)->toBe('With. Overlapping');
+    expect($result[3]->content)->toBe('Overlapping. Words');
+    expect($result[4]->content)->toBe('Another. Test. With');
+    expect($result[5]->content)->toBe('With. Overlapping');
+    expect($result[6]->content)->toBe('Overlapping. Words');
+});
+
+it('removes at least one word when overlapping', function () {
+    $document = new Document();
+    $document->content = 'This is a test with one overlapping word';
+    $result = DocumentSplitter::splitDocument($document, 30, ' ', 20);
+    expect($result[0]->content)->toBe('This is a test with one');
+    expect($result[1]->content)->toBe('is a test with one overlapping');
+    expect($result[2]->content)->toBe('a test with one overlapping word');
+});
+
+it('ignores overlap if <= 0', function () {
+    $document = new Document();
+    $document->content = 'This is a test';
+    $result = DocumentSplitter::splitDocument($document, 10, ' ', 0);
+    expect($result[0]->content)->toBe('This is a');
+    expect($result[1]->content)->toBe('test');
+
+    $document = new Document();
+    $document->content = 'This is a test';
+    $result = DocumentSplitter::splitDocument($document, 10, ' ', -1);
+    expect($result[0]->content)->toBe('This is a');
+    expect($result[1]->content)->toBe('test');
+});


### PR DESCRIPTION
Overlapping is defined by the amount of words to overlap. I figured this would be more useful compared to overlapping on amount of characters, which would result in half-words, which might decrease quality when calculating vectors, and which might confuse the LLM when retrieved.

This PR closes #138 (although I preferred amount of words instead of characters as stated above)

The new `createChunksWithOverlap` method should actually handle the case where `$wordOverlap === 0` too (so without overlap). The tests seem to run fine even if I use only the new method. But because there might be some unforeseen bugs, I opted to keep the original method as-is for now in case no overlapping is requested.

That way, I think this PR can be approved much more quickly too, because it shouldn't affect existing functionality at all.

**_IMPORTANT NOTE: I might have to make this more clear somehow, but it's not always words. By default, when splitting documents, we split per full sentence. This means that the value for `$wordOverlap` in that case is actually the amount of full sentences you want to overlap._**
