### PR TITLE
Small to big retrieval - part 1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,15 @@ CREATE TABLE IF NOT EXISTS test_place (
                                           sourcename text,
                                           embedding vector
 );
+CREATE TABLE IF NOT EXISTS test_doc (
+                                        id SERIAL PRIMARY KEY,
+                                        content text,
+                                        type text,
+                                        sourcetype text,
+                                        sourcename text,
+                                        embedding vector,
+                                        chunknumber int
+);
 ```
 
 Then run:

--- a/devx/pgvector/scripts/01.sql
+++ b/devx/pgvector/scripts/01.sql
@@ -6,5 +6,16 @@ CREATE TABLE IF NOT EXISTS test_place (
                                           type text,
                                           sourcetype text,
                                           sourcename text,
-                                          embedding vector
+                                          embedding vector,
+                                          chunknumber int
+);
+
+CREATE TABLE IF NOT EXISTS test_doc (
+                                          id SERIAL PRIMARY KEY,
+                                          content text,
+                                          type text,
+                                          sourcetype text,
+                                          sourcename text,
+                                          embedding vector,
+                                          chunknumber int
 );

--- a/src/Embeddings/DataReader/FileDataReader.php
+++ b/src/Embeddings/DataReader/FileDataReader.php
@@ -101,6 +101,7 @@ final class FileDataReader implements DataReader
         $document->content = $content;
         $document->sourceType = $this->sourceType;
         $document->sourceName = $entry;
+        $document->hash = \hash('sha256', $content);
 
         return $document;
     }

--- a/src/Embeddings/DocumentSplitter/DocumentSplitter.php
+++ b/src/Embeddings/DocumentSplitter/DocumentSplitter.php
@@ -27,7 +27,6 @@ final class DocumentSplitter
             return [$document];
         }
 
-        $chunks = [];
         $words = explode($separator, $text);
         if ($wordOverlap > 0) {
             $chunks = self::createChunksWithOverlap($words, $maxLength, $separator, $wordOverlap);

--- a/src/Embeddings/DocumentStore/DocumentStore.php
+++ b/src/Embeddings/DocumentStore/DocumentStore.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LLPhant\Embeddings\DocumentStore;
+
+use LLPhant\Embeddings\Document;
+
+interface DocumentStore
+{
+    public function addDocument(Document $document): void;
+
+    /**
+     * @param  Document[]  $documents
+     */
+    public function addDocuments(array $documents): void;
+
+    /**
+     * @return iterable<Document>
+     */
+    public function fetchDocumentsByChunkRange(string $sourceType, string $sourceName, int $leftIndex, int $rightIndex): iterable;
+}

--- a/src/Embeddings/VectorStores/Doctrine/DoctrineEmbeddingEntityBase.php
+++ b/src/Embeddings/VectorStores/Doctrine/DoctrineEmbeddingEntityBase.php
@@ -26,6 +26,9 @@ class DoctrineEmbeddingEntityBase extends Document
     #[ORM\Column(type: Types::TEXT)]
     public string $sourceName = 'manual';
 
+    #[ORM\Column(type: Types::INTEGER)]
+    public int $chunkNumber = 0;
+
     public function getId(): int
     {
         return $this->id;

--- a/src/Embeddings/VectorStores/Memory/MemoryVectorStore.php
+++ b/src/Embeddings/VectorStores/Memory/MemoryVectorStore.php
@@ -6,9 +6,10 @@ use Exception;
 use LLPhant\Embeddings\Distances\Distance;
 use LLPhant\Embeddings\Distances\EuclideanDistanceL2;
 use LLPhant\Embeddings\Document;
+use LLPhant\Embeddings\DocumentStore\DocumentStore;
 use LLPhant\Embeddings\VectorStores\VectorStoreBase;
 
-class MemoryVectorStore extends VectorStoreBase
+class MemoryVectorStore extends VectorStoreBase implements DocumentStore
 {
     /** @var Document[] */
     private array $documentsPool = [];
@@ -52,5 +53,21 @@ class MemoryVectorStore extends VectorStoreBase
         }
 
         return $results;
+    }
+
+    public function fetchDocumentsByChunkRange(string $sourceType, string $sourceName, int $leftIndex, int $rightIndex): iterable
+    {
+        // This is a naive implementation, just to create an example of a DocumentStore
+        $result = [];
+
+        foreach ($this->documentsPool as $document) {
+            if ($document->sourceType === $sourceType && $document->sourceName === $sourceName && $document->chunkNumber >= $leftIndex && $document->chunkNumber <= $rightIndex) {
+                $result[$document->chunkNumber] = $document;
+            }
+        }
+
+        \ksort($result);
+
+        return $result;
     }
 }

--- a/src/Embeddings/VectorStores/Milvus/MilvusClient.php
+++ b/src/Embeddings/VectorStores/Milvus/MilvusClient.php
@@ -117,6 +117,42 @@ class MilvusClient
 
     /**
      * @return array{code: int, data: mixed}
+     */
+    public function deleteCollection(string $collectionName): array
+    {
+        $path = 'vector/collections/drop';
+        $body = [
+            'collectionName' => $collectionName,
+        ];
+
+        return $this->sendRequest('POST', $path, $body);
+    }
+
+    /**
+     * @param  string[]|null  $outputFields
+     * @return array{code: int, data: mixed}
+     */
+    public function query(string $collectionName, ?array $outputFields = null, ?string $filter = null, int $limit = 100): array
+    {
+        $path = 'vector/query';
+        $body = [
+            'collectionName' => $collectionName,
+            'limit' => $limit,
+        ];
+
+        if ($outputFields !== null) {
+            $body['outputFields'] = $outputFields;
+        }
+
+        if ($filter !== null) {
+            $body['filter'] = $filter;
+        }
+
+        return $this->sendRequest('POST', $path, $body);
+    }
+
+    /**
+     * @return array{code: int, data: mixed}
      *
      * @phpstan-ignore-next-line
      */

--- a/src/Embeddings/VectorStores/Milvus/MilvusVectorStore.php
+++ b/src/Embeddings/VectorStores/Milvus/MilvusVectorStore.php
@@ -6,6 +6,7 @@ use LLPhant\Embeddings\Document;
 use LLPhant\Embeddings\DocumentStore\DocumentStore;
 use LLPhant\Embeddings\DocumentUtils;
 use LLPhant\Embeddings\VectorStores\VectorStoreBase;
+use LLPhant\Exception\SecurityException;
 
 class MilvusVectorStore extends VectorStoreBase implements DocumentStore
 {
@@ -88,8 +89,21 @@ class MilvusVectorStore extends VectorStoreBase implements DocumentStore
         $this->collectionExists = true;
     }
 
+    /**
+     * @throws SecurityException
+     */
     public function fetchDocumentsByChunkRange(string $sourceType, string $sourceName, int $leftIndex, int $rightIndex): iterable
     {
+        $filters = \FILTER_SANITIZE_ENCODED;
+
+        if ($sourceType !== \filter_var($sourceType, $filters)) {
+            throw new SecurityException('Invalid source type');
+        }
+
+        if ($sourceName !== \filter_var($sourceName, $filters)) {
+            throw new SecurityException('Invalid source name');
+        }
+
         $response = $this->client->query(
             $this->collectionName,
             self::OUTPUTFIELDS,

--- a/src/Embeddings/VectorStores/Milvus/MilvusVectorStore.php
+++ b/src/Embeddings/VectorStores/Milvus/MilvusVectorStore.php
@@ -3,12 +3,15 @@
 namespace LLPhant\Embeddings\VectorStores\Milvus;
 
 use LLPhant\Embeddings\Document;
+use LLPhant\Embeddings\DocumentStore\DocumentStore;
 use LLPhant\Embeddings\DocumentUtils;
 use LLPhant\Embeddings\VectorStores\VectorStoreBase;
 
-class MilvusVectorStore extends VectorStoreBase
+class MilvusVectorStore extends VectorStoreBase implements DocumentStore
 {
     final public const MILVUS_COLLECTION_NAME = 'llphant';
+
+    final public const OUTPUTFIELDS = ['id', 'content', 'formattedContent', 'sourceType', 'sourceName', 'hash', 'chunkNumber', 'embedding'];
 
     public bool $collectionExists = false;
 
@@ -45,9 +48,7 @@ class MilvusVectorStore extends VectorStoreBase
                 $documents
             )
         );
-        if ($response['code'] !== 200) {
-            throw new \Exception('Error while inserting data');
-        }
+        $this->checkResponseCode($response);
     }
 
     /**
@@ -63,11 +64,9 @@ class MilvusVectorStore extends VectorStoreBase
             $embedding,
             $k,
             array_key_exists('filter', $additionalArguments) ? $additionalArguments['filter'] : '',
-            ['id', 'content', 'formattedContent', 'sourceType', 'sourceName', 'hash', 'chunkNumber', 'embedding']
+            self::OUTPUTFIELDS
         );
-        if ($response['code'] !== 200) {
-            throw new \Exception('Error while searching vector');
-        }
+        $this->checkResponseCode($response);
 
         return DocumentUtils::createDocumentsFromArray($response['data']);
     }
@@ -85,9 +84,53 @@ class MilvusVectorStore extends VectorStoreBase
             primaryField: 'id',
             vectorField: 'embedding'
         );
-        if ($response['code'] !== 200) {
-            throw new \Exception('Error while creating collection');
-        }
+        $this->checkResponseCode($response);
         $this->collectionExists = true;
+    }
+
+    public function fetchDocumentsByChunkRange(string $sourceType, string $sourceName, int $leftIndex, int $rightIndex): iterable
+    {
+        $response = $this->client->query(
+            $this->collectionName,
+            self::OUTPUTFIELDS,
+            "sourceType == \"$sourceType\" and sourceName == \"$sourceName\" and ($leftIndex <= chunkNumber <= $rightIndex)",
+        );
+        $this->checkResponseCode($response);
+
+        $documents = DocumentUtils::createDocumentsFromArray($response['data']);
+
+        \usort($documents, fn (Document $d1, Document $d2): int => $d1->chunkNumber <=> $d2->chunkNumber);
+
+        return $documents;
+    }
+
+    /**
+     * @param  array<string, array<array<string, array<float>|int|string>>|int>  $response
+     */
+    private function checkResponseCode(array $response): void
+    {
+        /** @var int $responseCode */
+        $responseCode = $response['code'];
+        if ($responseCode !== 200) {
+            $msg = "Error while creating collection ($responseCode)";
+            if (\array_key_exists('message', $response)) {
+                /** @var string $responseMessage */
+                $responseMessage = $response['message'];
+                $msg .= ': '.$responseMessage;
+            }
+            throw new \Exception($msg);
+        }
+    }
+
+    public function deleteCollection(): bool
+    {
+        if (! $this->collectionExists) {
+            return false;
+        }
+
+        $response = $this->client->deleteCollection($this->collectionName);
+        $this->checkResponseCode($response);
+
+        return true;
     }
 }

--- a/src/Query/SemanticSearch/PipeDocumentsTransformer.php
+++ b/src/Query/SemanticSearch/PipeDocumentsTransformer.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LLPhant\Query\SemanticSearch;
+
+class PipeDocumentsTransformer implements RetrievedDocumentsTransformer
+{
+    /**
+     * @var RetrievedDocumentsTransformer[]
+     */
+    private readonly array $transformers;
+
+    public function __construct(RetrievedDocumentsTransformer ...$transformers)
+    {
+        $this->transformers = $transformers;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function transformDocuments(array $questions, array $retrievedDocs): array
+    {
+        $docs = $retrievedDocs;
+
+        foreach ($this->transformers as $transformer) {
+            $docs = $transformer->transformDocuments($questions, $docs);
+        }
+
+        return $docs;
+    }
+}

--- a/src/Query/SemanticSearch/SiblingsDocumentTransformer.php
+++ b/src/Query/SemanticSearch/SiblingsDocumentTransformer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace LLPhant\Query\SemanticSearch;
+
+use LLPhant\Embeddings\Document;
+use LLPhant\Embeddings\DocumentStore\DocumentStore;
+
+class SiblingsDocumentTransformer implements RetrievedDocumentsTransformer
+{
+    public function __construct(private readonly DocumentStore $documentStore, private readonly int $nrOfSiblings)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function transformDocuments(array $questions, array $retrievedDocs): array
+    {
+        /** @var Document[] $extraDocs */
+        $extraDocs = [];
+        foreach ($retrievedDocs as $retrievedDoc) {
+            [$leftIndex, $rightIndex] = $this->getIndices($retrievedDoc->chunkNumber, $this->nrOfSiblings);
+            \array_push(
+                $extraDocs,
+                ...$this->documentStore->fetchDocumentsByChunkRange($retrievedDoc->sourceType, $retrievedDoc->sourceName, $leftIndex, $rightIndex));
+        }
+
+        return $extraDocs;
+    }
+
+    /**
+     * @return int[]
+     */
+    private function getIndices(int $position, int $numElements): array
+    {
+        if ($position < 0 || $numElements <= 0) {
+            throw new \InvalidArgumentException('Both position and numElements must be positive integers.');
+        }
+
+        $halfDistance = intdiv($numElements - 1, 2);
+        $halfDistance = min($position, $halfDistance);
+        $leftIndex = $position - $halfDistance;
+        $rightIndex = $position + ($numElements - 1 - $halfDistance);
+
+        return [$leftIndex, $rightIndex];
+    }
+}

--- a/tests/Fixtures/DocumentFixtures.php
+++ b/tests/Fixtures/DocumentFixtures.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use LLPhant\Embeddings\Document;
+
+class DocumentFixtures
+{
+    private function __construct()
+    {
+    }
+
+    public static function documentChunk(int $i, string $sourceType, string $sourceName): Document
+    {
+        $document = new Document();
+        $document->sourceName = $sourceName;
+        $document->sourceType = $sourceType;
+        $document->chunkNumber = $i;
+        $document->content = 'Document '.$i;
+        $document->hash = \md5($document->content);
+        // Fake embedding
+        $document->embedding = [0.1, 0.2];
+
+        return $document;
+    }
+}

--- a/tests/Integration/Embeddings/VectorStores/Doctrine/SampleDocEntity.php
+++ b/tests/Integration/Embeddings/VectorStores/Doctrine/SampleDocEntity.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Embeddings\VectorStores\Doctrine;
+
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Table;
+use LLPhant\Embeddings\VectorStores\Doctrine\DoctrineEmbeddingEntityBase;
+
+#[Entity]
+#[Table(name: 'test_doc')]
+class SampleDocEntity extends DoctrineEmbeddingEntityBase
+{
+    public static function createDocument(string $type, string $name, string $content, int $chunkNumber): SampleDocEntity
+    {
+        $document = new SampleDocEntity();
+        $document->sourceType = $type;
+        $document->sourceName = $name;
+        $document->content = $content;
+        $document->chunkNumber = $chunkNumber;
+
+        // Just fake data, we don't need this in tests
+        $document->embedding = [0.1, 0.2];
+
+        return $document;
+    }
+}

--- a/tests/Integration/Embeddings/VectorStores/Milvus/MilvusVectorStoreTest.php
+++ b/tests/Integration/Embeddings/VectorStores/Milvus/MilvusVectorStoreTest.php
@@ -5,38 +5,74 @@ declare(strict_types=1);
 use LLPhant\Embeddings\DocumentUtils;
 use LLPhant\Embeddings\VectorStores\Milvus\MilvusClient;
 use LLPhant\Embeddings\VectorStores\Milvus\MilvusVectorStore;
+use Tests\Fixtures\DocumentFixtures;
 
-it('tests a full embedding flow with Milvus', function () {
-    // Get the already embeded france.txt and paris.txt documents
-    $path = __DIR__.'/../EmbeddedMock/francetxt_paristxt.json';
-    $rawFileContent = file_get_contents($path);
-    if (! $rawFileContent) {
-        throw new Exception('File not found');
-    }
+describe('MilvusVectorStore', function () {
+    beforeEach(function (): void {
+        $client = new MilvusClient(getenv('MILVUS_HOST') ?? 'localhost', '19530', 'root', 'milvus');
+        /** @var TestCase $this */
+        $this->vectorStore = new MilvusVectorStore($client);
+    });
 
-    $rawDocuments = json_decode($rawFileContent, true);
-    $embeddedDocuments = DocumentUtils::createDocumentsFromArray($rawDocuments);
+    afterEach(function (): void {
+        /** @var TestCase $this */
+        $this->vectorStore->deleteCollection();
+    });
 
-    // Get the embedding of "France the country"
-    $path = __DIR__.'/../EmbeddedMock/france_the_country_embedding.json';
-    $rawFileContent = file_get_contents($path);
-    if (! $rawFileContent) {
-        throw new Exception('File not found');
-    }
-    /** @var float[] $embeddingQuery */
-    $embeddingQuery = json_decode($rawFileContent, true);
+    it('tests a full embedding flow with Milvus', function () {
+        // Get the already embeded france.txt and paris.txt documents
+        $path = __DIR__.'/../EmbeddedMock/francetxt_paristxt.json';
+        $rawFileContent = file_get_contents($path);
+        if (! $rawFileContent) {
+            throw new Exception('File not found');
+        }
 
-    $client = new MilvusClient(getenv('MILVUS_HOST') ?? 'localhost', '19530', 'root', 'milvus');
-    $vectorStore = new MilvusVectorStore($client);
+        $rawDocuments = json_decode($rawFileContent, true);
+        $embeddedDocuments = DocumentUtils::createDocumentsFromArray($rawDocuments);
 
-    $vectorStore->addDocuments($embeddedDocuments);
+        // Get the embedding of "France the country"
+        $path = __DIR__.'/../EmbeddedMock/france_the_country_embedding.json';
+        $rawFileContent = file_get_contents($path);
+        if (! $rawFileContent) {
+            throw new Exception('File not found');
+        }
+        /** @var float[] $embeddingQuery */
+        $embeddingQuery = json_decode($rawFileContent, true);
 
-    $searchResult1 = $vectorStore->similaritySearch($embeddingQuery, 2);
-    expect(DocumentUtils::getFirstWordFromContent($searchResult1[0]))->toBe('France');
+        $this->vectorStore->addDocuments($embeddedDocuments);
 
-    $requestParam = [
-        'filter' => 'sourceName == "paris.txt"',
-    ];
-    $searchResult2 = $vectorStore->similaritySearch($embeddingQuery, 2, $requestParam);
-    expect(DocumentUtils::getFirstWordFromContent($searchResult2[0]))->toBe('Paris');
+        $searchResult1 = $this->vectorStore->similaritySearch($embeddingQuery, 2);
+        expect(DocumentUtils::getFirstWordFromContent($searchResult1[0]))->toBe('France');
+
+        $requestParam = [
+            'filter' => 'sourceName == "paris.txt"',
+        ];
+        $searchResult2 = $this->vectorStore->similaritySearch($embeddingQuery, 2, $requestParam);
+        expect(DocumentUtils::getFirstWordFromContent($searchResult2[0]))->toBe('Paris');
+    });
+
+    it('can fetch documents by chunk range', function () {
+        $this->vectorStore->addDocuments([
+            DocumentFixtures::documentChunk(1, 'typex', 'namey'),
+            DocumentFixtures::documentChunk(0, 'typex', 'namey'),
+            DocumentFixtures::documentChunk(3, 'typex', 'namey'),
+            DocumentFixtures::documentChunk(2, 'typex', 'namey'),
+            DocumentFixtures::documentChunk(4, 'typex', 'namey'),
+            DocumentFixtures::documentChunk(0, 'typex', 'namez'),
+            DocumentFixtures::documentChunk(1, 'typex', 'namez'),
+            DocumentFixtures::documentChunk(2, 'typex', 'namez'),
+            DocumentFixtures::documentChunk(0, 'typez', 'namey'),
+            DocumentFixtures::documentChunk(1, 'typez', 'namey'),
+            DocumentFixtures::documentChunk(2, 'typez', 'namey'),
+        ]);
+
+        $range = $this->vectorStore->fetchDocumentsByChunkRange('typex', 'namey', 0, 2);
+        expect(\array_map(fn ($d) => DocumentUtils::getUniqueId($d), $range))->toBe(
+            [
+                DocumentUtils::getUniqueId(DocumentFixtures::documentChunk(0, 'typex', 'namey')),
+                DocumentUtils::getUniqueId(DocumentFixtures::documentChunk(1, 'typex', 'namey')),
+                DocumentUtils::getUniqueId(DocumentFixtures::documentChunk(2, 'typex', 'namey')),
+            ]
+        );
+    });
 });

--- a/tests/Integration/Embeddings/VectorStores/Milvus/MilvusVectorStoreTest.php
+++ b/tests/Integration/Embeddings/VectorStores/Milvus/MilvusVectorStoreTest.php
@@ -12,6 +12,7 @@ describe('MilvusVectorStore', function () {
         $client = new MilvusClient(getenv('MILVUS_HOST') ?? 'localhost', '19530', 'root', 'milvus');
         /** @var TestCase $this */
         $this->vectorStore = new MilvusVectorStore($client);
+        $this->vectorStore->deleteCollection();
     });
 
     afterEach(function (): void {

--- a/tests/Integration/Query/SemanticSearch/SampleDocuments/cukoo.txt
+++ b/tests/Integration/Query/SemanticSearch/SampleDocuments/cukoo.txt
@@ -1,0 +1,7 @@
+The cuckoo game is a card game that requires a deck of 99.5 cards.
+
+The colors of the cards are orange, green and blue.
+
+Only inhabitants of the planet Grock can also use yellow-colored cards.
+
+The dynamics of the game are inspired by Russell's antinomy: a coral-colored card is required to win, but the coral-colored card is always in the hand of a player who cannot win.

--- a/tests/Integration/Query/SemanticSearch/SiblingsDocumentTransformerTest.php
+++ b/tests/Integration/Query/SemanticSearch/SiblingsDocumentTransformerTest.php
@@ -7,7 +7,6 @@ namespace Tests\Integration\Query\SemanticSearch;
 use LLPhant\Chat\OpenAIChat;
 use LLPhant\Embeddings\DataReader\FileDataReader;
 use LLPhant\Embeddings\DocumentSplitter\DocumentSplitter;
-use LLPhant\Embeddings\EmbeddingFormatter\EmbeddingFormatter;
 use LLPhant\Embeddings\EmbeddingGenerator\OpenAI\OpenAI3SmallEmbeddingGenerator;
 use LLPhant\Embeddings\VectorStores\Memory\MemoryVectorStore;
 use LLPhant\Query\SemanticSearch\QuestionAnswering;
@@ -17,7 +16,7 @@ it('can be used to get bigger chunks from small ones', function () {
     $filePath = __DIR__.'/SampleDocuments';
     $reader = new FileDataReader($filePath);
     $documents = $reader->getDocuments();
-    $splittedDocuments = DocumentSplitter::splitDocuments($documents, 100, "\n");
+    $splittedDocuments = DocumentSplitter::splitDocuments($documents, 5, "\n");
 
     $embeddingGenerator = new OpenAI3SmallEmbeddingGenerator();
     $embeddedDocuments = $embeddingGenerator->embedDocuments($splittedDocuments);

--- a/tests/Integration/Query/SemanticSearch/SiblingsDocumentTransformerTest.php
+++ b/tests/Integration/Query/SemanticSearch/SiblingsDocumentTransformerTest.php
@@ -4,5 +4,35 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Query\SemanticSearch;
 
-it('Todo: write this test', function () {
+use LLPhant\Chat\OpenAIChat;
+use LLPhant\Embeddings\DataReader\FileDataReader;
+use LLPhant\Embeddings\DocumentSplitter\DocumentSplitter;
+use LLPhant\Embeddings\EmbeddingFormatter\EmbeddingFormatter;
+use LLPhant\Embeddings\EmbeddingGenerator\OpenAI\OpenAI3SmallEmbeddingGenerator;
+use LLPhant\Embeddings\VectorStores\Memory\MemoryVectorStore;
+use LLPhant\Query\SemanticSearch\QuestionAnswering;
+use LLPhant\Query\SemanticSearch\SiblingsDocumentTransformer;
+
+it('can be used to get bigger chunks from small ones', function () {
+    $filePath = __DIR__.'/SampleDocuments';
+    $reader = new FileDataReader($filePath);
+    $documents = $reader->getDocuments();
+    $splittedDocuments = DocumentSplitter::splitDocuments($documents, 100, "\n");
+
+    $embeddingGenerator = new OpenAI3SmallEmbeddingGenerator();
+    $embeddedDocuments = $embeddingGenerator->embedDocuments($splittedDocuments);
+
+    $vectorStore = new MemoryVectorStore();
+    $vectorStore->addDocuments($embeddedDocuments);
+
+    $siblingsTransformer = new SiblingsDocumentTransformer($vectorStore, 3);
+    $embeddingGenerator = new OpenAI3SmallEmbeddingGenerator();
+    $qa = new QuestionAnswering(
+        $vectorStore,
+        $embeddingGenerator,
+        new OpenAIChat(),
+        retrievedDocumentsTransformer: $siblingsTransformer
+    );
+    $answer = $qa->answerQuestion('Can I win at cukoo if I have a coral card?');
+    expect($answer)->toContain('cuckoo');
 });

--- a/tests/Integration/Query/SemanticSearch/SiblingsDocumentTransformerTest.php
+++ b/tests/Integration/Query/SemanticSearch/SiblingsDocumentTransformerTest.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Query\SemanticSearch;
+
+it('Todo: write this test', function () {
+});

--- a/tests/Unit/Embeddings/DataReader/FileDataReaderTest.php
+++ b/tests/Unit/Embeddings/DataReader/FileDataReaderTest.php
@@ -21,6 +21,16 @@ it('can read various types of documents', function (string $docName, string $sta
     ['data-pdf.pdf', 'This data is from a pdf'],
 ]);
 
+it('computes the hash of the content', function (string $docName) {
+    $filePath = __DIR__.'/FilesTestDirectory/'.$docName;
+    $reader = new FileDataReader($filePath);
+    $documents = $reader->getDocuments();
+
+    expect($documents[0]->hash)->toBe(\hash('sha256', $documents[0]->content));
+})->with([
+    'hello.txt', 'hello2.txt',
+]);
+
 it('can read pdf and texts ', function () {
     $filePath = __DIR__.'/FilesTestDirectory/';
     $reader = new FileDataReader($filePath);

--- a/tests/Unit/Embeddings/DocumentSplitter/DocumentSplitterTest.php
+++ b/tests/Unit/Embeddings/DocumentSplitter/DocumentSplitterTest.php
@@ -64,6 +64,10 @@ it('adds overlap when splitting documents', function () {
     expect($result[1]->content)->toBe('with one overlapping');
     expect($result[2]->content)->toBe('overlapping word');
 
+    expect($result[0]->chunkNumber)->toBe(0);
+    expect($result[1]->chunkNumber)->toBe(1);
+    expect($result[2]->chunkNumber)->toBe(2);
+
     $document = new Document();
     $document->content = 'This is a test with two overlapping words';
     $result = DocumentSplitter::splitDocument($document, 20, ' ', 2);

--- a/tests/Unit/Embeddings/VectorStores/FileSystem/FileSystemVectorStoreTest.php
+++ b/tests/Unit/Embeddings/VectorStores/FileSystem/FileSystemVectorStoreTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Chat;
+
+use LLPhant\Embeddings\DocumentUtils;
+use LLPhant\Embeddings\VectorStores\FileSystem\FileSystemVectorStore;
+use Tests\Fixtures\DocumentFixtures;
+use Tests\TestCase;
+
+describe('FileSystemVectorStore', function () {
+    beforeEach(function (): void {
+        /** @var TestCase $this */
+        $this->fileSystemVectorStore = new FileSystemVectorStore();
+        $this->fileSystemVectorStore->deleteStore();
+    });
+
+    afterEach(function (): void {
+        /** @var TestCase $this */
+        $this->fileSystemVectorStore->deleteStore();
+    });
+
+    it('can fetch documents by chunk range', function () {
+        /** @var TestCase $this */
+        $this->fileSystemVectorStore->addDocuments([
+            DocumentFixtures::documentChunk(1, 'typex', 'namey'),
+            DocumentFixtures::documentChunk(0, 'typex', 'namey'),
+            DocumentFixtures::documentChunk(3, 'typex', 'namey'),
+            DocumentFixtures::documentChunk(2, 'typex', 'namey'),
+            DocumentFixtures::documentChunk(4, 'typex', 'namey'),
+            DocumentFixtures::documentChunk(0, 'typex', 'namez'),
+            DocumentFixtures::documentChunk(1, 'typex', 'namez'),
+            DocumentFixtures::documentChunk(2, 'typex', 'namez'),
+            DocumentFixtures::documentChunk(0, 'typez', 'namey'),
+            DocumentFixtures::documentChunk(1, 'typez', 'namey'),
+            DocumentFixtures::documentChunk(2, 'typez', 'namey'),
+        ]);
+
+        $range = $this->fileSystemVectorStore->fetchDocumentsByChunkRange('typex', 'namey', 0, 2);
+        expect(\array_map(fn ($d) => DocumentUtils::getUniqueId($d), $range))->toBe(
+            [
+                DocumentUtils::getUniqueId(DocumentFixtures::documentChunk(0, 'typex', 'namey')),
+                DocumentUtils::getUniqueId(DocumentFixtures::documentChunk(1, 'typex', 'namey')),
+                DocumentUtils::getUniqueId(DocumentFixtures::documentChunk(2, 'typex', 'namey')),
+            ]
+        );
+    });
+});

--- a/tests/Unit/Embeddings/VectorStores/Memory/MemoryVectorStoreTest.php
+++ b/tests/Unit/Embeddings/VectorStores/Memory/MemoryVectorStoreTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit\Chat;
+
+use LLPhant\Embeddings\DocumentUtils;
+use LLPhant\Embeddings\VectorStores\Memory\MemoryVectorStore;
+use Tests\Fixtures\DocumentFixtures;
+
+it('can fetch documents by chunk range', function () {
+    $memoryVectorStore = new MemoryVectorStore();
+    $memoryVectorStore->addDocuments([
+        DocumentFixtures::documentChunk(1, 'typex', 'namey'),
+        DocumentFixtures::documentChunk(0, 'typex', 'namey'),
+        DocumentFixtures::documentChunk(3, 'typex', 'namey'),
+        DocumentFixtures::documentChunk(2, 'typex', 'namey'),
+        DocumentFixtures::documentChunk(4, 'typex', 'namey'),
+        DocumentFixtures::documentChunk(0, 'typex', 'namez'),
+        DocumentFixtures::documentChunk(1, 'typex', 'namez'),
+        DocumentFixtures::documentChunk(2, 'typex', 'namez'),
+        DocumentFixtures::documentChunk(0, 'typez', 'namey'),
+        DocumentFixtures::documentChunk(1, 'typez', 'namey'),
+        DocumentFixtures::documentChunk(2, 'typez', 'namey'),
+    ]);
+
+    $range = $memoryVectorStore->fetchDocumentsByChunkRange('typex', 'namey', 0, 2);
+    expect(\array_map(fn ($d) => DocumentUtils::getUniqueId($d), $range))->toBe(
+        [
+            DocumentUtils::getUniqueId(DocumentFixtures::documentChunk(0, 'typex', 'namey')),
+            DocumentUtils::getUniqueId(DocumentFixtures::documentChunk(1, 'typex', 'namey')),
+            DocumentUtils::getUniqueId(DocumentFixtures::documentChunk(2, 'typex', 'namey')),
+        ]
+    );
+});

--- a/tests/Unit/Embeddings/VectorStores/Milvus/MilvusVectorStoreTest.php
+++ b/tests/Unit/Embeddings/VectorStores/Milvus/MilvusVectorStoreTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use LLPhant\Embeddings\DocumentUtils;
+use LLPhant\Embeddings\VectorStores\Milvus\MilvusClient;
+use LLPhant\Embeddings\VectorStores\Milvus\MilvusVectorStore;
+use LLPhant\Exception\SecurityException;
+
+it('can detect wrong sourceType input', function (string $input) {
+    $vectorStore = new MilvusVectorStore(Mockery::mock(MilvusClient::class));
+    $vectorStore->fetchDocumentsByChunkRange($input, 'aName', 0, 2);
+})->with(['"', '%u0022', "'"])->throws(SecurityException::class, 'Invalid source type');
+
+it('can detect wrong sourceName input', function (string $input) {
+    $vectorStore = new MilvusVectorStore(Mockery::mock(MilvusClient::class));
+    $vectorStore->fetchDocumentsByChunkRange('aType', $input, 0, 2);
+})->with(['"', '%u0022', "'"])->throws(SecurityException::class, 'Invalid source name');
+
+it('can call Milvus and decode response the right way', function () {
+    $client = Mockery::mock(MilvusClient::class);
+    $client->shouldReceive('query')->andReturn([
+        'code' => 200,
+        'data' => [
+            [
+                'chunkNumber' => 1,
+                'content' => 'Document 1',
+                'embedding' => [0.1, 0.2],
+                'hash' => 'f08a4cd1811d38fab7ed7ef8763b8fc1',
+                'id' => 453153871437234298,
+                'sourceName' => 'aName',
+                'sourceType' => 'aType',
+            ],
+        ],
+    ]);
+    $vectorStore = new MilvusVectorStore($client);
+    $documents = $vectorStore->fetchDocumentsByChunkRange('aType', 'aName', 0, 2);
+    expect($documents)->toHaveCount(1)
+        ->and(DocumentUtils::getUniqueId($documents[0]))->toBe('aType:aName:1');
+});

--- a/tests/Unit/Query/SemanticSearch/PipeDocumentTransformerTest.php
+++ b/tests/Unit/Query/SemanticSearch/PipeDocumentTransformerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Query\SemanticSearch;
+
+use LLPhant\Embeddings\DocumentUtils;
+use LLPhant\Query\SemanticSearch\PipeDocumentsTransformer;
+use LLPhant\Query\SemanticSearch\RetrievedDocumentsTransformer;
+
+function transformer(string $color): RetrievedDocumentsTransformer
+{
+    return new class($color) implements RetrievedDocumentsTransformer
+    {
+        public function __construct(private readonly string $color)
+        {
+        }
+
+        public function transformDocuments(array $questions, array $retrievedDocs): array
+        {
+            foreach ($retrievedDocs as $retrievedDoc) {
+                $retrievedDoc->content .= ' '.$this->color;
+            }
+
+            return $retrievedDocs;
+        }
+    };
+}
+
+it('can pipe transformations', function () {
+    $transformer = new PipeDocumentsTransformer(transformer('green'), transformer('white'), transformer('red'));
+    $transformed = $transformer->transformDocuments(['sample'], DocumentUtils::documents('one', 'two', 'three'));
+    expect($transformed[0]->content)->toBe('one green white red')
+        ->and($transformed[1]->content)->toBe('two green white red')
+        ->and($transformed[2]->content)->toBe('three green white red');
+});

--- a/tests/Unit/Query/SemanticSearch/SiblingsDocumentTransformerTest.php
+++ b/tests/Unit/Query/SemanticSearch/SiblingsDocumentTransformerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Query\SemanticSearch;
+
+use LLPhant\Embeddings\Document;
+use LLPhant\Embeddings\DocumentStore\DocumentStore;
+use LLPhant\Query\SemanticSearch\SiblingsDocumentTransformer;
+use Tests\Fixtures\DocumentFixtures;
+
+function documentStore(): DocumentStore
+{
+    return new class implements DocumentStore
+    {
+        public function fetchDocumentsByChunkRange(string $sourceType, string $sourceName, int $leftIndex, int $rightIndex): array
+        {
+            /** @var Document[] $documents */
+            $documents = [];
+            for ($i = $leftIndex; $i <= $rightIndex; $i++) {
+                $documents[] = DocumentFixtures::documentChunk($i, $sourceType, $sourceName);
+            }
+
+            return $documents;
+        }
+
+        public function addDocument(Document $document): void
+        {
+            // Unused
+        }
+
+        public function addDocuments(array $documents): void
+        {
+            // Unused
+        }
+    };
+}
+
+it('can extract right data from document store', function () {
+    $documents = [DocumentFixtures::documentChunk(7, 'txt', 'test')];
+    $transformer = new SiblingsDocumentTransformer(documentStore(), 20);
+    $transformedDocuments = $transformer->transformDocuments(['Sample question'], $documents);
+    expect(count($transformedDocuments))->toBe(20)
+        ->and($transformedDocuments[0]->chunkNumber)->toBe(0)
+        ->and($transformedDocuments[19]->chunkNumber)->toBe(19);
+});


### PR DESCRIPTION
Hi @MaximeThoonsen and @synio-wesley ,

this is a first idea toward the implementation of Small to Big retrieval. (https://github.com/theodo-group/LLPhant/issues/179)

Many things are still missing, first of all a new `RetrievedDocumentsTransformer` to remove duplicated documents, remove overlappings and create a union document from the retrieved chunks.

I'm not sure about the signature of `DocumentStore::fetchDocumentsByChunkRange`. I don't know if the hash of the document should also be added to the parameters besides `$sourceType` and `$sourceName`, since it's not mandatory that those two parameter identify a document uniquely:
https://github.com/theodo-group/LLPhant/blob/25fc657580871f46a6bfc3c4a269cc93d1a65f3c/src/Embeddings/Document.php#L18
