### PR TITLE
Introduced `OllamaChat->functionsCalled` to provide info on all tools called

### DIFF
--- a/src/Chat/CalledFunction/CalledFunction.php
+++ b/src/Chat/CalledFunction/CalledFunction.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace LLPhant\Chat\CalledFunction;
+
+use LLPhant\Chat\FunctionInfo\FunctionInfo;
+
+class CalledFunction
+{
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public function __construct(public FunctionInfo $definition, public array $arguments, public string $return)
+    {
+    }
+}

--- a/src/Chat/OllamaChat.php
+++ b/src/Chat/OllamaChat.php
@@ -89,6 +89,7 @@ class OllamaChat implements ChatInterface
 
         if ($this->functionsCalled) {
             $lastKey = array_key_last($this->functionsCalled);
+
             return $this->functionsCalled[$lastKey]->definition;
         }
 
@@ -101,6 +102,7 @@ class OllamaChat implements ChatInterface
 
         if ($this->functionsCalled) {
             $lastKey = array_key_last($this->functionsCalled);
+
             return $this->functionsCalled[$lastKey]->definition;
         }
 

--- a/src/Chat/OllamaChat.php
+++ b/src/Chat/OllamaChat.php
@@ -6,6 +6,7 @@ namespace LLPhant\Chat;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Utils;
+use LLPhant\Chat\CalledFunction\CalledFunction;
 use LLPhant\Chat\FunctionInfo\FunctionInfo;
 use LLPhant\Chat\FunctionInfo\ToolFormatter;
 use LLPhant\Exception\HttpException;
@@ -34,7 +35,7 @@ class OllamaChat implements ChatInterface
     /** @var FunctionInfo[] */
     private array $tools = [];
 
-    /** @var array<array> */
+    /** @var CalledFunction[] */
     public array $functionsCalled = [];
 
     public function __construct(protected OllamaConfig $config)
@@ -88,7 +89,7 @@ class OllamaChat implements ChatInterface
 
         if ($this->functionsCalled) {
             $lastKey = array_key_last($this->functionsCalled);
-            $lastFunctionCalled = $this->functionsCalled[$lastKey]['definition'];
+            $lastFunctionCalled = $this->functionsCalled[$lastKey]->definition;
             if ($lastFunctionCalled instanceof FunctionInfo) {
                 return $lastFunctionCalled;
             }
@@ -103,7 +104,7 @@ class OllamaChat implements ChatInterface
 
         if ($this->functionsCalled) {
             $lastKey = array_key_last($this->functionsCalled);
-            $lastFunctionCalled = $this->functionsCalled[$lastKey]['definition'];
+            $lastFunctionCalled = $this->functionsCalled[$lastKey]->definition;
             if ($lastFunctionCalled instanceof FunctionInfo) {
                 return $lastFunctionCalled;
             }
@@ -342,11 +343,7 @@ class OllamaChat implements ChatInterface
         $functionToCall = $this->getFunctionInfoFromName($functionName);
         $return = $functionToCall->callWithArguments($arguments);
 
-        $this->functionsCalled[] = [
-            'definition' => $functionToCall,
-            'arguments' => $arguments,
-            'return' => $return,
-        ];
+        $this->functionsCalled[] = new CalledFunction($functionToCall, $arguments, $return);
 
         return $return;
     }

--- a/src/Chat/OllamaChat.php
+++ b/src/Chat/OllamaChat.php
@@ -89,10 +89,7 @@ class OllamaChat implements ChatInterface
 
         if ($this->functionsCalled) {
             $lastKey = array_key_last($this->functionsCalled);
-            $lastFunctionCalled = $this->functionsCalled[$lastKey]->definition;
-            if ($lastFunctionCalled instanceof FunctionInfo) {
-                return $lastFunctionCalled;
-            }
+            return $this->functionsCalled[$lastKey]->definition;
         }
 
         return $answer;
@@ -104,10 +101,7 @@ class OllamaChat implements ChatInterface
 
         if ($this->functionsCalled) {
             $lastKey = array_key_last($this->functionsCalled);
-            $lastFunctionCalled = $this->functionsCalled[$lastKey]->definition;
-            if ($lastFunctionCalled instanceof FunctionInfo) {
-                return $lastFunctionCalled;
-            }
+            return $this->functionsCalled[$lastKey]->definition;
         }
 
         return $answer;

--- a/src/Chat/OllamaChat.php
+++ b/src/Chat/OllamaChat.php
@@ -34,7 +34,7 @@ class OllamaChat implements ChatInterface
     /** @var FunctionInfo[] */
     private array $tools = [];
 
-    /** @var array<array>  */
+    /** @var array<array> */
     public array $functionsCalled = [];
 
     public function __construct(protected OllamaConfig $config)


### PR DESCRIPTION
This is in direct reference to https://github.com/theodo-group/LLPhant/issues/208, ollama has the ability to call multiple tools for each use prompt, thus the `OllamaChat->lastFunctionCalled` property is not enough.

This PR:
- introduces `OllamaChat->functionsCalled` containing definition/arguments/return for each called tool
- removes `OllamaChat->lastToolsOutput` that was just introduced in https://github.com/theodo-group/LLPhant/pull/207
- removes `OllamaChat->lastFunctionCalled` (raises question below)

Question:
- `OllamaChat->lastFunctionCalled` is also used in OpenAI/Ahtropic adapters, we may want to keep it in OllamaChat just for uniformity but I don't know, opinions?
- ~~instead of `functionsCalled` being an array, we may want to introduce a new class with 3 properties definition/arguments/return, it would be cleaner, but I don't know about the naming etc, thus waiting for feedback.~~

TODO:
- tests, will write them if you like the general idea

Fixes https://github.com/theodo-group/LLPhant/issues/208