### PR TITLE
Add openai-php/client v0.10.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.1.0",
         "guzzlehttp/guzzle": "^7.4.5",
         "guzzlehttp/psr7": "^2.7",
-        "openai-php/client": "^v0.7.7 || ^v0.8.4 || ^v0.9.2",
+        "openai-php/client": "^v0.7.7 || ^v0.8.4 || ^v0.9.2 || ^v0.10.1",
         "phpoffice/phpword": "^1.3.0",
         "psr/http-message": "^2.0",
         "smalot/pdfparser": "^2.7"

--- a/tests/Unit/Chat/MockOpenAIClient.php
+++ b/tests/Unit/Chat/MockOpenAIClient.php
@@ -17,6 +17,7 @@ use OpenAI\Contracts\Resources\ImagesContract;
 use OpenAI\Contracts\Resources\ModelsContract;
 use OpenAI\Contracts\Resources\ModerationsContract;
 use OpenAI\Contracts\Resources\ThreadsContract;
+use OpenAI\Contracts\Resources\VectorStoresContract;
 
 class MockOpenAIClient implements ClientContract
 {
@@ -88,5 +89,10 @@ class MockOpenAIClient implements ClientContract
     public function batches(): BatchesContract
     {
         // TODO: Implement batches() method.
+    }
+
+    public function vectorStores(): VectorStoresContract
+    {
+        // TODO: Implement vectorStores() method.
     }
 }


### PR DESCRIPTION
Support for the latest version of openai-php/client

Let me know if you still want to remove the old versions - https://github.com/theodo-group/LLPhant/pull/167#issuecomment-2204493740