### PR TITLE
Support alternate OpenAI API-compatible servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 We designed this framework to be as simple as possible, while still providing you with the tools you need to build powerful apps.
 It is compatible with Symfony and Laravel.
 
-We are working to expand the support of different LLMs. Right now, we are supporting [OpenAI](https://openai.com/blog/openai-api), [Anthropic](https://www.anthropic.com/), [Mistral](https://mistral.ai/) and [Ollama](https://ollama.ai/) 
+We are working to expand the support of different LLMs. Right now, we are supporting [OpenAI](https://openai.com/blog/openai-api), [Anthropic](https://www.anthropic.com/), [Mistral](https://mistral.ai/), [Ollama](https://ollama.ai/), and services compatible with the OpenAI API such as [LocalAI](https://localai.io/).
 Ollama that can be used to run LLM locally such as [Llama 2](https://llama.meta.com/).
 
 We want to thank few amazing projects that we use here or inspired us:
@@ -126,6 +126,24 @@ Creating a chat with no configuration will use a CLAUDE_3_HAIKU model.
 
 ```php
 $chat = new AnthropicChat();
+```
+
+### OpenAI compatible APIs like LocalAI
+
+The most simple way to allow the call to OpenAI is to set the OPENAI_API_KEY and OPENAI_BASE_URL environment variable.
+
+```bash
+export OPENAI_API_KEY=-
+export OPENAI_BASE_URL=http://local.ai:8080/v1
+```
+
+You can also create an OpenAIConfig object and pass it to the constructor of the OpenAIChat or OpenAIEmbeddings.
+
+```php
+$config = new OpenAIConfig();
+$config->apiKey = '-';
+$config->url = 'http://local.ai:8080/v1';
+$chat = new OpenAIChat($config);
 ```
 
 ### Chat

--- a/src/Audio/OpenAIAudio.php
+++ b/src/Audio/OpenAIAudio.php
@@ -29,7 +29,7 @@ class OpenAIAudio
             $this->client = OpenAI::factory()
                 ->withApiKey($apiKey)
                 ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
-                ->withBaseUri($config->url ?? 'api.openai.com/v1')
+                ->withBaseUri($config->url ?? (getenv('OPENAI_BASE_URL') ?: 'api.openai.com/v1'))
                 ->make();
         }
         $this->model = $config->model ?? OpenAIAudioModel::Whisper1->value;

--- a/src/Audio/OpenAIAudio.php
+++ b/src/Audio/OpenAIAudio.php
@@ -2,6 +2,7 @@
 
 namespace LLPhant\Audio;
 
+use Exception;
 use LLPhant\OpenAIConfig;
 use OpenAI;
 use OpenAI\Contracts\ClientContract;

--- a/src/Audio/OpenAIAudio.php
+++ b/src/Audio/OpenAIAudio.php
@@ -22,10 +22,14 @@ class OpenAIAudio
         } else {
             $apiKey = $config->apiKey ?? getenv('OPENAI_API_KEY');
             if (! $apiKey) {
-                throw new \Exception('You have to provide a OPENAI_API_KEY env var to request OpenAI .');
+                throw new Exception('You have to provide a OPENAI_API_KEY env var to request OpenAI .');
             }
 
-            $this->client = OpenAI::client($apiKey);
+            $this->client = OpenAI::factory()
+                ->withApiKey($apiKey)
+                ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
+                ->withBaseUri($config->url ?? 'api.openai.com/v1')
+                ->make();
         }
         $this->model = $config->model ?? OpenAIAudioModel::Whisper1->value;
         // See https://platform.openai.com/docs/api-reference/audio/createTranscription for possible options

--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -51,7 +51,11 @@ class OpenAIChat implements ChatInterface
                 throw new Exception('You have to provide a OPENAI_API_KEY env var to request OpenAI .');
             }
 
-            $this->client = OpenAI::client($apiKey);
+            $this->client = OpenAI::factory()
+                ->withApiKey($apiKey)
+                ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
+                ->withBaseUri($config->url ?? 'api.openai.com/v1')
+                ->make();
         }
         $this->model = $config->model ?? OpenAIChatModel::Gpt4Turbo->value;
         $this->modelOptions = $config->modelOptions ?? [];

--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -54,7 +54,7 @@ class OpenAIChat implements ChatInterface
             $this->client = OpenAI::factory()
                 ->withApiKey($apiKey)
                 ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
-                ->withBaseUri($config->url ?? 'api.openai.com/v1')
+                ->withBaseUri($config->url ?? (getenv('OPENAI_BASE_URL') ?: 'api.openai.com/v1'))
                 ->make();
         }
         $this->model = $config->model ?? OpenAIChatModel::Gpt4Turbo->value;

--- a/src/Embeddings/EmbeddingGenerator/OpenAI/AbstractOpenAIEmbeddingGenerator.php
+++ b/src/Embeddings/EmbeddingGenerator/OpenAI/AbstractOpenAIEmbeddingGenerator.php
@@ -41,7 +41,7 @@ abstract class AbstractOpenAIEmbeddingGenerator implements EmbeddingGeneratorInt
             if (! $apiKey) {
                 throw new Exception('You have to provide a OPENAI_API_KEY env var to request OpenAI .');
             }
-            $url = $config->url ?? 'api.openai.com/v1';
+            $url = $config->url ?? (getenv('OPENAI_BASE_URL') ?: 'api.openai.com/v1');
 
             $this->client = OpenAI::factory()
                 ->withApiKey($apiKey)

--- a/src/Embeddings/EmbeddingGenerator/OpenAI/AbstractOpenAIEmbeddingGenerator.php
+++ b/src/Embeddings/EmbeddingGenerator/OpenAI/AbstractOpenAIEmbeddingGenerator.php
@@ -41,8 +41,14 @@ abstract class AbstractOpenAIEmbeddingGenerator implements EmbeddingGeneratorInt
             if (! $apiKey) {
                 throw new Exception('You have to provide a OPENAI_API_KEY env var to request OpenAI .');
             }
+            $url = $config->url ?? 'api.openai.com/v1';
 
-            $this->client = OpenAI::client($apiKey);
+            $this->client = OpenAI::factory()
+                ->withApiKey($apiKey)
+                ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
+                ->withBaseUri($url)
+                ->make();
+            $this->uri = $url.'/embeddings';
             $this->apiKey = $apiKey;
         }
     }

--- a/src/Image/OpenAIImage.php
+++ b/src/Image/OpenAIImage.php
@@ -35,7 +35,7 @@ class OpenAIImage implements ImageInterface
             $this->client = OpenAI::factory()
                 ->withApiKey($apiKey)
                 ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
-                ->withBaseUri($config->url ?? 'api.openai.com/v1')
+                ->withBaseUri($config->url ?? (getenv('OPENAI_BASE_URL') ?: 'api.openai.com/v1'))
                 ->make();
         }
         $this->model = $config->model ?? OpenAIImageModel::DallE3->value;

--- a/src/Image/OpenAIImage.php
+++ b/src/Image/OpenAIImage.php
@@ -32,7 +32,11 @@ class OpenAIImage implements ImageInterface
                 throw new Exception('You have to provide a OPENAI_API_KEY env var to request OpenAI .');
             }
 
-            $this->client = OpenAI::client($apiKey);
+            $this->client = OpenAI::factory()
+                ->withApiKey($apiKey)
+                ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
+                ->withBaseUri($config->url ?? 'api.openai.com/v1')
+                ->make();
         }
         $this->model = $config->model ?? OpenAIImageModel::DallE3->value;
         $this->modelOptions = $config->modelOptions ?? [];

--- a/src/OpenAIConfig.php
+++ b/src/OpenAIConfig.php
@@ -10,6 +10,8 @@ class OpenAIConfig
 {
     public string $apiKey;
 
+    public string $url = 'api.openai.com/v1';
+
     public ?ClientContract $client = null;
 
     public string $model;


### PR DESCRIPTION
Added option to change OpenAI base url so you can use it with servers like LocalAI and others.  You can set it via the OPENAI_BASE_URL environment variable or in the OpenAIConfig $url variable.