### PR TITLE
Function name

### DIFF
--- a/src/Chat/Message.php
+++ b/src/Chat/Message.php
@@ -10,6 +10,8 @@ class Message
 
     public string $content;
 
+    public string $name;
+
     public static function system(string $content): self
     {
         $message = new self();
@@ -37,11 +39,12 @@ class Message
         return $message;
     }
 
-    public static function functionResult(string $content): self
+    public static function functionResult(string $content, string $name): self
     {
         $message = new self();
         $message->role = ChatRole::Function;
         $message->content = $content;
+        $message->name = $name;
 
         return $message;
     }

--- a/tests/Integration/Chat/OpenAIChatTest.php
+++ b/tests/Integration/Chat/OpenAIChatTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Chat;
 
+use LLPhant\Chat\Enums\OpenAIChatModel;
 use LLPhant\Chat\FunctionInfo\FunctionBuilder;
 use LLPhant\Chat\FunctionInfo\FunctionInfo;
 use LLPhant\Chat\FunctionInfo\Parameter;
@@ -108,8 +109,11 @@ it('calls tool functions during a chat', function () {
     expect($notifier->nrOfCalls)->toBe(1);
 });
 
-it('can call a function provide the result to the assistant', function () {
-    $chat = new OpenAIChat();
+it('can call a function and provide the result to the assistant', function () {
+    $config = new OpenAIConfig();
+    //Functions work only with older models. Tools are needed with newer models
+    $config->model = OpenAIChatModel::Gpt35Turbo->value;
+    $chat = new OpenAIChat($config);
     $location = new Parameter('location', 'string', 'the name of the city, the state or province and the nation');
     $weatherExample = new WeatherExample();
 
@@ -140,7 +144,9 @@ it('can call a function provide the result to the assistant', function () {
         $functionInfo->name
     );
 
-    $chat->generateChatOrReturnFunctionCalled($messages);
+    $response = $chat->generateChatOrReturnFunctionCalled($messages);
 
-    expect($chat->getTotalTokens())->toBeGreaterThan($firstRequestTokenUsage);
+    expect($response)->toBeString()
+        ->and($response)->toContain('sunny')
+        ->and($chat->getTotalTokens())->toBeGreaterThan($firstRequestTokenUsage);
 });

--- a/tests/Unit/Chat/OpenAIChatTest.php
+++ b/tests/Unit/Chat/OpenAIChatTest.php
@@ -20,6 +20,29 @@ it('no error when construct with no model', function () {
     expect(isset($chat))->toBeTrue();
 });
 
+it('can process system, user, assistant and functionResult messages', function () {
+    $client = new MockOpenAIClient();
+
+    $config = new OpenAIConfig();
+    $config->client = $client;
+
+    $chat = new OpenAIChat($config);
+
+    $messages = [
+        Message::system('You are an AI that answers to questions about weather in certain locations by calling external services to get the information'),
+        Message::user('What is the weather in Venice?'),
+        Message::functionResult(
+            'Weather in Venice is sunny, temperature is 26 Celsius',
+            'currentWeatherForLocation'
+        ),
+        Message::assistant('The current weather in Venice is sunny with passing clouds. The temperature is around 26°C (78.8°F)'),
+        Message::user('Thank you'),
+    ];
+    $response = $chat->generateChatOrReturnFunctionCalled($messages);
+
+    expect($response)->toBeString();
+});
+
 it('returns a stream response using generateStreamOfText()', function () {
     $response = new Response(
         200,

--- a/tests/Unit/Chat/OpenAIChatTest.php
+++ b/tests/Unit/Chat/OpenAIChatTest.php
@@ -35,8 +35,6 @@ it('can process system, user, assistant and functionResult messages', function (
             'Weather in Venice is sunny, temperature is 26 Celsius',
             'currentWeatherForLocation'
         ),
-        Message::assistant('The current weather in Venice is sunny with passing clouds. The temperature is around 26°C (78.8°F)'),
-        Message::user('Thank you'),
     ];
     $response = $chat->generateChatOrReturnFunctionCalled($messages);
 


### PR DESCRIPTION
This is a minor change on top of #194 (thanks to @kaeldric, whose commits are included here) and it is a preparation for next introduction of `tool_call_id` to `Message` with role `Tool`.
Tools are needed in newer models.
I think that introducing `tool_call_id` is needed also for addressing issue #219 