### PR TITLE
feat(qdrant): allow default vector as usual in qdrant

### DIFF
--- a/tests/Integration/Embeddings/VectorStores/Qdrant/QdrantVectorStoreTest.php
+++ b/tests/Integration/Embeddings/VectorStores/Qdrant/QdrantVectorStoreTest.php
@@ -12,6 +12,7 @@ use LLPhant\Embeddings\EmbeddingGenerator\OpenAI\OpenAIADA002EmbeddingGenerator;
 use LLPhant\Embeddings\VectorStores\Qdrant\QdrantVectorStore;
 use Qdrant\Config;
 use Qdrant\Models\Filter\Condition\MatchString;
+use Qdrant\Models\Request\VectorParams;
 
 it('tests a full embedding flow with Qdrant', function () {
     $filePath = __DIR__.'/../PlacesTextFiles';
@@ -30,6 +31,41 @@ it('tests a full embedding flow with Qdrant', function () {
 
     $collectionName = 'places2';
     $vectorStore = new QdrantVectorStore($config, $collectionName);
+    $vectorStore->createCollectionIfDoesNotExist($collectionName, $embeddingGenerator->getEmbeddingLength());
+    $vectorStore->addDocuments($embededDocuments);
+    $embedding = $embeddingGenerator->embedText('France the country');
+    /** @var Document[] $result */
+    $result = $vectorStore->similaritySearch($embedding, 2);
+
+    // We check that the search return the correct entities in the right order
+    expect(explode(' ', $result[0]->content)[0])->toBe('France');
+
+    $condition = new MatchString('sourceName', 'paris.txt');
+
+    $filter['must'] = [$condition];
+
+    /** @var Document[] $searchResult2 */
+    $searchResult2 = $vectorStore->similaritySearch($embedding, 2, $filter);
+    expect(explode(' ', $searchResult2[0]->content)[0])->toBe('Paris');
+});
+
+it('tests a full embedding flow with Qdrant and euclid distance and null vector name', function () {
+    $filePath = __DIR__.'/../PlacesTextFiles';
+    $reader = new FileDataReader($filePath, Document::class);
+    $documents = $reader->getDocuments();
+    $splittedDocuments = DocumentSplitter::splitDocuments($documents, 100, "\n");
+    $formattedDocuments = EmbeddingFormatter::formatEmbeddings($splittedDocuments);
+
+    $embeddingGenerator = new OpenAIADA002EmbeddingGenerator();
+    $embededDocuments = $embeddingGenerator->embedDocuments($formattedDocuments);
+
+    $host = getenv('QDRANT_HOST');
+    $apiKey = getenv('QDRANT_API_KEY');
+    $config = new Config($host);
+    $config->setApiKey($apiKey);
+
+    $collectionName = 'places3';
+    $vectorStore = new QdrantVectorStore($config, $collectionName, null, VectorParams::DISTANCE_EUCLID);
     $vectorStore->createCollectionIfDoesNotExist($collectionName, $embeddingGenerator->getEmbeddingLength());
     $vectorStore->addDocuments($embededDocuments);
     $embedding = $embeddingGenerator->embedText('France the country');

--- a/tests/Unit/Embeddings/VectorStores/Qdrant/FakeQdrant.php
+++ b/tests/Unit/Embeddings/VectorStores/Qdrant/FakeQdrant.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Unit\Embeddings\VectorStores\Qdrant;
+
+use ArrayAccess;
+use ArrayIterator;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use IteratorAggregate;
+use LLPhant\Embeddings\VectorStores\Qdrant\QdrantVectorStore;
+use Qdrant\Config;
+use Qdrant\Http\Transport;
+use Qdrant\Qdrant;
+use Traversable;
+
+class History implements ArrayAccess, IteratorAggregate
+{
+    private $container = [];
+
+    public function offsetExists($offset): bool
+    {
+        return isset($this->container[$offset]);
+    }
+
+    public function offsetGet($offset): mixed
+    {
+        return $this->container[$offset] ?? null;
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        if (is_null($offset)) {
+            $this->container[] = $value;
+        } else {
+            $this->container[$offset] = $value;
+        }
+    }
+
+    public function offsetUnset($offset): void
+    {
+        unset($this->container[$offset]);
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->container);
+    }
+}
+
+class FakeQdrant extends Qdrant
+{
+    public const QDRANT_COLLECTION_LIST = <<<'JSON'
+    {
+        "result": [
+            {
+                "id": "c4ff4e3f62b63f67f34d3e64e7c53ca5f12dba0035bd471eae8f2ef0f5689432",
+                "version": 0,
+                "score": 0.83347666,
+                "payload": {
+                    "id": "c4ff4e3f62b63f67f34d3e64e7c53ca5f12dba0035bd471eae8f2ef0f5689432",
+                    "content": "France (French: [fʁɑ̃s] Listen), officially the French Republic (French: République française [ʁepyblik fʁɑ̃sɛz]),[14] is a country located primarily in Western Europe. It also includes overseas regions and territories in the Americas and the Atlantic,Pacific and Indian Oceans,[XII] giving it one of the largest discontiguous exclusive economic zones in the world.",
+                    "formattedContent": "The name of the source is: france.txt.France (French: [fʁɑ̃s] Listen), officially the French Republic (French: République française [ʁepyblik fʁɑ̃sɛz]),[14] is a country located primarily in Western Europe. It also includes overseas regions and territories in the Americas and the Atlantic,Pacific and Indian Oceans,[XII] giving it one of the largest discontiguous exclusive economic zones in the world.",
+                    "sourceType": "files",
+                    "sourceName": "france.txt",
+                    "hash": "5b2e0d71b7355c6ac802fb259b0bd822e54770b0949ec379363932eac1ef28fa",
+                    "chunkNumber": 1
+                }
+            },
+            {
+                "_id": "3a2dd7a8d86884ddc79569aaaba2f58d1e1fe2096aa2fbfc0a622008891aba34",
+                "version": 0,
+                "score": 0.83347666,
+                "payload": {
+                    "_id": "3a2dd7a8d86884ddc79569aaaba2f58d1e1fe2096aa2fbfc0a622008891aba34",
+                    "content": "The house is on fire",
+                    "formattedContent": "The name of the source is: france.txt.The house is on fire",
+                    "sourceType": "files",
+                    "sourceName": "france.txt",
+                    "hash": "5773aa044e790575ee1a9cbefff632c6c643881f493b62fb6dd7b2ca1b2b1861",
+                    "chunkNumber": 2
+                }
+            }
+        ]
+    }
+    JSON;
+
+    public function __construct(public QdrantVectorStore $qdrantStore, public $history)
+    {
+    }
+
+    public static function create(string $body): FakeQdrant
+    {
+        $mock = new MockHandler([
+            new Response(200, ['content-type' => 'application/json'], $body),
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $history = new History([]);
+        $historyMiddleware = Middleware::history($history);
+        $handlerStack->push($historyMiddleware);
+
+        $client = new Client(['handler' => $handlerStack]);
+        $config = new Config('fakeHost', 1111);
+        $qdrantStore = new QdrantVectorStore($config, 'collection');
+        $qdrantStore->setClient(new Qdrant(new Transport($client, $config)));
+
+        return new FakeQdrant($qdrantStore, $history);
+
+    }
+}

--- a/tests/Unit/Embeddings/VectorStores/Qdrant/QdrantVectorStoreTest.php
+++ b/tests/Unit/Embeddings/VectorStores/Qdrant/QdrantVectorStoreTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit\Embeddings\VectorStores\Qdrant;
+
+use Qdrant\Models\Request\VectorParams;
+
+it('can create collection', function () {
+    $fake = FakeQdrant::create(FakeQdrant::QDRANT_COLLECTION_LIST);
+    $qdrantStore = $fake->qdrantStore;
+    $history = $fake->history;
+    $qdrantStore->createCollection('oneCollection', 512);
+    $content = $history[0]['request']->getBody()->getContents();
+    expect($content)->toBe('{"vectors":{"openai":{"size":512,"distance":"Cosine"}}}');
+});
+
+it('can create collection with null vectorName', function () {
+    $fake = FakeQdrant::create(FakeQdrant::QDRANT_COLLECTION_LIST);
+    $qdrantStore = $fake->qdrantStore;
+    $history = $fake->history;
+    $qdrantStore->setVectorName(null);
+    $qdrantStore->createCollection('oneCollection', 512);
+    $content = $history[0]['request']->getBody()->getContents();
+    expect($content)->toBe('{"vectors":{"size":512,"distance":"Cosine"}}');
+});
+
+it('can set distance', function () {
+    $fake = FakeQdrant::create(FakeQdrant::QDRANT_COLLECTION_LIST);
+    $qdrantStore = $fake->qdrantStore;
+    $history = $fake->history;
+    $qdrantStore->setDistance(VectorParams::DISTANCE_EUCLID);
+    $qdrantStore->createCollection('oneCollection', 512);
+    $content = $history[0]['request']->getBody()->getContents();
+    expect($content)->toBe('{"vectors":{"openai":{"size":512,"distance":"Euclid"}}}');
+});
+
+it('can perform similarity search', function () {
+    $fakeEmbedding = [];
+    $qdrantStore = FakeQdrant::create(FakeQdrant::QDRANT_COLLECTION_LIST)->qdrantStore;
+    $response = $qdrantStore->similaritySearch($fakeEmbedding, 2);
+    expect($response)->toHaveCount(2)
+        ->and($response[0]->content)->toStartWith('France')
+        ->and($response[1]->content)->toBe('The house is on fire');
+});


### PR DESCRIPTION
This feature allows the default vector to be used as usual in qdrant, ensuring compatibility and consistency with existing functionalities.