### PR TITLE
[Vector Store] Support OpenSearch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "hkulekci/qdrant": "This is required for the QdrantVectoreStore.",
         "predis/predis": "This is required for the RedisVectoreStore.",
         "elasticsearch/elasticsearch": "This is required for the ElasticsearchVectoreStore.",
-        "codewithkyrian/chromadb-php": "This is required for the ChromaDBVectorStore."
+        "codewithkyrian/chromadb-php": "This is required for the ChromaDBVectorStore.",
+        "opensearch-project/opensearch-php": "This is required for the OpenSearchVectorStore."
     },
     "require-dev": {
         "codewithkyrian/chromadb-php": "^0.3.0",
@@ -32,6 +33,7 @@
         "hkulekci/qdrant": "^v0.5.3",
         "laravel/pint": "v1.15.3",
         "mockery/mockery": "^1.6",
+        "opensearch-project/opensearch-php": "^2.3",
         "pestphp/pest": "2.32.0",
         "pestphp/pest-plugin-arch": "^2.5.0",
         "pestphp/pest-plugin-type-coverage": "2.8.0",

--- a/devx/docker-compose-opensearch.yml
+++ b/devx/docker-compose-opensearch.yml
@@ -1,0 +1,37 @@
+services:
+  opensearch:
+    image: opensearchproject/opensearch:2.17.1
+    container_name: opensearch
+    environment:
+      discovery.type: single-node
+      node.name: opensearch
+      OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
+    volumes:
+      - opensearch-data:/usr/share/opensearch/data
+    ports:
+      - 9200:9200
+      - 9600:9600
+    networks:
+      - opensearch-net
+
+  opensearch-dashboards:
+    image: opensearchproject/opensearch-dashboards:2.17.1
+    container_name: opensearch-dashboards
+    ports:
+      - 5601:5601
+    expose:
+      - "5601"
+    environment:
+      OPENSEARCH_HOSTS: '["https://opensearch:9200"]'
+    networks:
+      - opensearch-net
+    depends_on:
+      - opensearch
+
+volumes:
+  opensearch-data:
+    driver: local
+
+networks:
+  opensearch-net:
+    driver: bridge

--- a/devx/docker-compose-opensearch.yml
+++ b/devx/docker-compose-opensearch.yml
@@ -6,6 +6,7 @@ services:
       discovery.type: single-node
       node.name: opensearch
       OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: "OpenSearch2.17"
     volumes:
       - opensearch-data:/usr/share/opensearch/data
     ports:

--- a/src/Embeddings/VectorStores/OpenSearch/OpenSearchVectorStore.php
+++ b/src/Embeddings/VectorStores/OpenSearch/OpenSearchVectorStore.php
@@ -121,9 +121,7 @@ class OpenSearchVectorStore extends VectorStoreBase
     /**
      * {@inheritDoc}
      *
-     * @param  array{filter?: string|array<string, mixed>, num_candidates?: int}  $additionalArguments
-     *
-     * num_candidates is used to tune approximate k-NN for speed or accuracy
+     * @param  array{filter?: string|array<string, mixed>}  $additionalArguments
      */
     public function similaritySearch(array $embedding, int $k = 4, array $additionalArguments = []): array
     {

--- a/src/Embeddings/VectorStores/OpenSearch/OpenSearchVectorStore.php
+++ b/src/Embeddings/VectorStores/OpenSearch/OpenSearchVectorStore.php
@@ -176,7 +176,7 @@ class OpenSearchVectorStore extends VectorStoreBase
             return;
         }
 
-        /** @var array{string: array{mappings: array{embedding: array{mapping: array{embedding: array{dims: int}}}}}} $response */
+        /** @var array{string: array{mappings: array{embedding: array{mapping: array{embedding: array{dimension: int}}}}}} $response */
         $response = $this->client->indices()->getFieldMapping([
             'index' => $this->indexName,
             'fields' => 'embedding',
@@ -185,7 +185,7 @@ class OpenSearchVectorStore extends VectorStoreBase
 
         if (
             array_key_exists('embedding', $mappings)
-            && $mappings['embedding']['mapping']['embedding']['dims'] === $vectorDim
+            && $mappings['embedding']['mapping']['embedding']['dimension'] === $vectorDim
         ) {
             return;
         }

--- a/src/Embeddings/VectorStores/OpenSearch/OpenSearchVectorStore.php
+++ b/src/Embeddings/VectorStores/OpenSearch/OpenSearchVectorStore.php
@@ -199,6 +199,10 @@ class OpenSearchVectorStore extends VectorStoreBase
                         'dimension' => $vectorDim,
                         'index' => true,
                         'similarity' => 'cosine',
+                        'method' => [
+                            'name' => 'hnsw',
+                            'engine' => 'lucene',
+                        ],
                     ],
                 ],
             ],

--- a/src/Embeddings/VectorStores/OpenSearch/OpenSearchVectorStore.php
+++ b/src/Embeddings/VectorStores/OpenSearch/OpenSearchVectorStore.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLPhant\Embeddings\VectorStores\OpenSearch;
+
+use LLPhant\Embeddings\Document;
+use LLPhant\Embeddings\VectorStores\VectorStoreBase;
+use OpenSearch\Client;
+use RuntimeException;
+
+class OpenSearchVectorStore extends VectorStoreBase
+{
+    final public const OS_INDEX = 'llphant';
+
+    public bool $vectorDimSet = false;
+
+    public function __construct(public Client $client, public string $indexName = self::OS_INDEX)
+    {
+        if ($client->indices()->exists(['index' => $indexName])) {
+            return;
+        }
+
+        $mapping = [
+            'index' => $indexName,
+            'body' => [
+                'settings' => [
+                    'index' => [
+                        'knn' => true,
+                    ],
+                ],
+                'mappings' => [
+                    'properties' => [
+                        'content' => [
+                            'type' => 'text',
+                        ],
+                        'formattedContent' => [
+                            'type' => 'text',
+                        ],
+                        'sourceType' => [
+                            'type' => 'keyword',
+                        ],
+                        'sourceName' => [
+                            'type' => 'keyword',
+                        ],
+                        'hash' => [
+                            'type' => 'keyword',
+                        ],
+                        'chunkNumber' => [
+                            'type' => 'integer',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $client->indices()->create($mapping);
+    }
+
+    public function addDocument(Document $document): void
+    {
+        if ($document->embedding === null) {
+            throw new RuntimeException('Document embedding must be set before adding a document.');
+        }
+
+        $this->setVectorDimIfNotSet(count((array) $document->embedding));
+
+        $this->client->index([
+            'index' => $this->indexName,
+            'body' => [
+                'embedding' => $document->embedding,
+                'content' => $document->content,
+                'formattedContent' => $document->formattedContent ?? '',
+                'sourceType' => $document->sourceType,
+                'sourceName' => $document->sourceName,
+                'hash' => $document->hash,
+                'chunkNumber' => $document->chunkNumber,
+            ],
+        ]);
+        $this->client->indices()->refresh(['index' => $this->indexName]);
+    }
+
+    /**
+     * @param  Document[]  $documents
+     */
+    public function addDocuments(array $documents, int $numberOfDocumentsPerRequest = 0): void
+    {
+        if ($documents === []) {
+            return;
+        }
+
+        if ($documents[0]->embedding === null) {
+            throw new RuntimeException('Document embedding must be set before adding a document.');
+        }
+
+        $this->setVectorDimIfNotSet(count((array) $documents[0]->embedding));
+
+        $params = ['body' => []];
+
+        foreach ($documents as $document) {
+            $params['body'][] = [
+                'index' => [
+                    '_index' => $this->indexName,
+                ],
+            ];
+            $params['body'][] = [
+                'embedding' => $document->embedding,
+                'content' => $document->content,
+                'formattedContent' => $document->formattedContent ?? '',
+                'sourceType' => $document->sourceType,
+                'sourceName' => $document->sourceName,
+                'hash' => $document->hash,
+                'chunkNumber' => $document->chunkNumber,
+            ];
+        }
+
+        $this->client->bulk($params);
+        $this->client->indices()->refresh(['index' => $this->indexName]);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param  array{filter?: string|array<string, mixed>, num_candidates?: int}  $additionalArguments
+     *
+     * num_candidates is used to tune approximate k-NN for speed or accuracy
+     */
+    public function similaritySearch(array $embedding, int $k = 4, array $additionalArguments = []): array
+    {
+        $searchParams = [
+            'index' => $this->indexName,
+            'body' => [
+                'query' => [
+                    'knn' => [
+                        'embedding' => [
+                            'vector' => $embedding,
+                            'k' => $k,
+                        ],
+                    ],
+                ],
+                'sort' => [
+                    [
+                        '_score' => [
+                            'order' => 'desc',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        if (array_key_exists('filter', $additionalArguments)) {
+            $searchParams['body']['query']['knn']['embedding']['filter'] = $additionalArguments['filter'];
+        }
+
+        /** @var array{hits: array{hits: array{array{_source: array{embedding: float[], content: string, formattedContent: string, sourceType: string, sourceName: string, hash: string, chunkNumber: int}}}}} $rawResponse */
+        $rawResponse = $this->client->search($searchParams);
+
+        $documents = [];
+
+        foreach ($rawResponse['hits']['hits'] as $hit) {
+            $document = new Document();
+            $document->embedding = $hit['_source']['embedding'];
+            $document->content = $hit['_source']['content'];
+            $document->formattedContent = $hit['_source']['formattedContent'];
+            $document->sourceType = $hit['_source']['sourceType'];
+            $document->sourceName = $hit['_source']['sourceName'];
+            $document->hash = $hit['_source']['hash'];
+            $document->chunkNumber = $hit['_source']['chunkNumber'];
+            $documents[] = $document;
+        }
+
+        return $documents;
+    }
+
+    private function setVectorDimIfNotSet(int $vectorDim): void
+    {
+        if ($this->vectorDimSet) {
+            return;
+        }
+
+        /** @var array{string: array{mappings: array{embedding: array{mapping: array{embedding: array{dims: int}}}}}} $response */
+        $response = $this->client->indices()->getFieldMapping([
+            'index' => $this->indexName,
+            'fields' => 'embedding',
+        ]);
+        $mappings = $response[$this->indexName]['mappings'];
+
+        if (
+            array_key_exists('embedding', $mappings)
+            && $mappings['embedding']['mapping']['embedding']['dims'] === $vectorDim
+        ) {
+            return;
+        }
+
+        $this->client->indices()->putMapping([
+            'index' => $this->indexName,
+            'body' => [
+                'properties' => [
+                    'embedding' => [
+                        'type' => 'knn_vector',
+                        'dimension' => $vectorDim,
+                        'index' => true,
+                        'similarity' => 'cosine',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->vectorDimSet = true;
+    }
+}

--- a/tests/Integration/Embeddings/VectorStores/OpenSearch/OpenSearchVectorStoreTest.php
+++ b/tests/Integration/Embeddings/VectorStores/OpenSearch/OpenSearchVectorStoreTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use LLPhant\Embeddings\DocumentUtils;
+use LLPhant\Embeddings\VectorStores\OpenSearch\OpenSearchVectorStore;
+use OpenSearch\ClientBuilder;
+
+it('tests a full embedding flow with OpenSearch', function () {
+    // Get the already embeded france.txt and paris.txt documents
+    $path = __DIR__.'/../EmbeddedMock/francetxt_paristxt.json';
+    $rawFileContent = file_get_contents($path);
+    if (! $rawFileContent) {
+        throw new RuntimeException('File not found');
+    }
+
+    $rawDocuments = json_decode($rawFileContent, true);
+    $embeddedDocuments = DocumentUtils::createDocumentsFromArray($rawDocuments);
+
+    // Get the embedding of "France the country"
+    $path = __DIR__.'/../EmbeddedMock/france_the_country_embedding.json';
+    $rawFileContent = file_get_contents($path);
+    if (! $rawFileContent) {
+        throw new RuntimeException('File not found');
+    }
+    /** @var float[] $embeddingQuery */
+    $embeddingQuery = json_decode($rawFileContent, true);
+
+    $client = (new ClientBuilder())::create()
+        ->setHosts([getenv('OPEN_SEARCH_URL') ?? 'https://localhost:9200'])
+        ->setBasicAuthentication('admin', 'OpenSearch2.17')
+        ->build();
+    $vectorStore = new OpenSearchVectorStore($client, 'llphant_test');
+
+    $vectorStore->addDocuments($embeddedDocuments);
+
+    $searchResult1 = $vectorStore->similaritySearch($embeddingQuery, 2);
+    expect(DocumentUtils::getFirstWordFromContent($searchResult1[0]))->toBe('France');
+
+    $requestParam = [
+        'filter' => [
+            'term' => [
+                'sourceName' => 'paris.txt',
+            ],
+        ],
+    ];
+    $searchResult2 = $vectorStore->similaritySearch($embeddingQuery, 2, $requestParam);
+    expect(DocumentUtils::getFirstWordFromContent($searchResult2[0]))->toBe('Paris');
+});

--- a/tests/Integration/Embeddings/VectorStores/OpenSearch/OpenSearchVectorStoreTest.php
+++ b/tests/Integration/Embeddings/VectorStores/OpenSearch/OpenSearchVectorStoreTest.php
@@ -37,9 +37,10 @@ it('tests a full embedding flow with OpenSearch', function () {
     $client = (new ClientBuilder())::create()
         ->setHosts($hosts)
         ->setBasicAuthentication('admin', 'OpenSearch2.17')
+        ->setSSLVerification(false)
         ->build();
-    $vectorStore = new OpenSearchVectorStore($client, 'llphant_test');
 
+    $vectorStore = new OpenSearchVectorStore($client, 'llphant_test');
     $vectorStore->addDocuments($embeddedDocuments);
 
     $searchResult1 = $vectorStore->similaritySearch($embeddingQuery, 2);


### PR DESCRIPTION
This PR adds support for the OpenSearch vector store. The main differences to the Elasticsearch vector store implementation are:

- Index settings (`'knn' => true`)
- Changes to query structure in similarity search
- Removal of "num_candidates" → not available in OpenSearch
- Mapping API differences for embedding field
- Minor changes of client API integration

Link to feature request: https://github.com/theodo-group/LLPhant/issues/242

**TODO:**

- [x] Docker Compose Support for OpenSearch
- [x] Tests