### PR TITLE
fix: set HTTPS for all OpenAI URLs

### DIFF
--- a/src/Audio/OpenAIAudio.php
+++ b/src/Audio/OpenAIAudio.php
@@ -29,7 +29,7 @@ class OpenAIAudio
             $this->client = OpenAI::factory()
                 ->withApiKey($apiKey)
                 ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
-                ->withBaseUri($config->url ?? (getenv('OPENAI_BASE_URL') ?: 'api.openai.com/v1'))
+                ->withBaseUri($config->url ?? (getenv('OPENAI_BASE_URL') ?: 'https://api.openai.com/v1'))
                 ->make();
         }
         $this->model = $config->model ?? OpenAIAudioModel::Whisper1->value;

--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -54,7 +54,7 @@ class OpenAIChat implements ChatInterface
             $this->client = OpenAI::factory()
                 ->withApiKey($apiKey)
                 ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
-                ->withBaseUri($config->url ?? (getenv('OPENAI_BASE_URL') ?: 'api.openai.com/v1'))
+                ->withBaseUri($config->url ?? (getenv('OPENAI_BASE_URL') ?: 'https://api.openai.com/v1'))
                 ->make();
         }
         $this->model = $config->model ?? OpenAIChatModel::Gpt4Turbo->value;

--- a/src/Image/OpenAIImage.php
+++ b/src/Image/OpenAIImage.php
@@ -35,7 +35,7 @@ class OpenAIImage implements ImageInterface
             $this->client = OpenAI::factory()
                 ->withApiKey($apiKey)
                 ->withHttpHeader('OpenAI-Beta', 'assistants=v2')
-                ->withBaseUri($config->url ?? (getenv('OPENAI_BASE_URL') ?: 'api.openai.com/v1'))
+                ->withBaseUri($config->url ?? (getenv('OPENAI_BASE_URL') ?: 'https://api.openai.com/v1'))
                 ->make();
         }
         $this->model = $config->model ?? OpenAIImageModel::DallE3->value;

--- a/src/OpenAIConfig.php
+++ b/src/OpenAIConfig.php
@@ -10,7 +10,7 @@ class OpenAIConfig
 {
     public string $apiKey;
 
-    public string $url = 'api.openai.com/v1';
+    public string $url = 'https://api.openai.com/v1';
 
     public ?ClientContract $client = null;
 


### PR DESCRIPTION
This seems to have come from https://github.com/theodo-group/LLPhant/pull/233

When we use the latest version to embed a document, we get this error from the OpenAI API:

```
{
    "error": {
      "type": "invalid_request_error",
      "code": "http_unsupported",
      "message": "The OpenAI API is only accessible over HTTPS. Ensure the URL starts with 'https://' and not 'http://'.",
      "param": null
    }
  }
```

It looks like someone else tried to fix it in this commit but there were other cases to also update.
https://github.com/theodo-group/LLPhant/commit/a423f2f5c78e8cfeb3468b1a0292117bb15c8672#diff-3f621a2c1806f726b861dcf2eeaa1f96e4a5e5d929f15041d082107e8d87f520R44