### PR TITLE
Added images input support for Ollama

### DIFF
--- a/docusaurus/docs/features.md
+++ b/docusaurus/docs/features.md
@@ -1,11 +1,11 @@
 # Comparison Table of all supported Language Models
 
-| Model     |  Text  | Streaming |    Tools    | Images input | Images output | Speech to text  |
-|-----------|:------:|:-----:|:-----------:|:------------:|:-------------:|:---------------:|
-| Anthropic |   ✅    |   ✅   |      ✅      |              |               |                 |
-| Mistral   |   ✅    |   ✅   |            |              |               |                 |
-| Ollama    |   ✅    |   ✅   | Some models |              |               |                 |
-| OpenAI    |   ✅    |   ✅   |      ✅      |      ✅       |       ✅       |        ✅      |
+| Model     |  Text   | Streaming |    Tools    | Images input | Images output | Speech to text  |
+|-----------|:-------:|:---------:|:-----------:|:------------:|:-------------:|:---------------:|
+| Anthropic |   ✅    |    ✅     |      ✅     |              |               |                 |
+| Mistral   |   ✅    |    ✅     |             |              |               |                 |
+| Ollama    |   ✅    |    ✅     | Some models | Some models  |               |                 |
+| OpenAI    |   ✅    |    ✅     |      ✅     |      ✅      |       ✅      |        ✅       |
 
 # Supported Vector Stores
 

--- a/src/Chat/OllamaChat.php
+++ b/src/Chat/OllamaChat.php
@@ -331,7 +331,7 @@ class OllamaChat implements ChatInterface
             $response[] = [
                 'role' => $msg->role,
                 'content' => $msg->content,
-                'images' => $images
+                'images' => $images,
             ];
         }
 

--- a/src/Chat/OllamaChat.php
+++ b/src/Chat/OllamaChat.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\Utils;
 use LLPhant\Chat\CalledFunction\CalledFunction;
 use LLPhant\Chat\FunctionInfo\FunctionInfo;
 use LLPhant\Chat\FunctionInfo\ToolFormatter;
+use LLPhant\Chat\Vision\VisionMessage;
 use LLPhant\Exception\HttpException;
 use LLPhant\Exception\MissingParameterException;
 use LLPhant\OllamaConfig;
@@ -329,7 +330,7 @@ class OllamaChat implements ChatInterface
                 'content' => $msg->content,
             ];
 
-            if ($msg->images) {
+            if ($msg instanceof VisionMessage) {
                 $responseMessage['images'] = [];
                 foreach ($msg->images as $image) {
                     $responseMessage['images'][] = $image->getBase64($this->client);

--- a/src/Chat/OllamaChat.php
+++ b/src/Chat/OllamaChat.php
@@ -315,27 +315,31 @@ class OllamaChat implements ChatInterface
      */
     protected function prepareMessages(array $messages): array
     {
-        $response = [];
+        $responseMessages = [];
         // The system message is always the first
         if (isset($this->systemMessage->role)) {
-            $response[] = [
+            $responseMessages[] = [
                 'role' => $this->systemMessage->role,
                 'content' => $this->systemMessage->content,
             ];
         }
         foreach ($messages as $msg) {
-            $images = [];
-            foreach ($msg->images as $image) {
-                $images[] = $image->getBase64($this->client);
-            }
-            $response[] = [
+            $responseMessage = [
                 'role' => $msg->role,
                 'content' => $msg->content,
-                'images' => $images,
             ];
+
+            if ($msg->images) {
+                $responseMessage['images'] = [];
+                foreach ($msg->images as $image) {
+                    $responseMessage['images'][] = $image->getBase64($this->client);
+                }
+            }
+
+            $responseMessages[] = $responseMessage;
         }
 
-        return $response;
+        return $responseMessages;
     }
 
     /**

--- a/src/Chat/OllamaChat.php
+++ b/src/Chat/OllamaChat.php
@@ -324,9 +324,14 @@ class OllamaChat implements ChatInterface
             ];
         }
         foreach ($messages as $msg) {
+            $images = [];
+            foreach ($msg->images as $image) {
+                $images[] = $image->getBase64($this->client);
+            }
             $response[] = [
                 'role' => $msg->role,
                 'content' => $msg->content,
+                'images' => $images
             ];
         }
 

--- a/src/Chat/Vision/ImageSource.php
+++ b/src/Chat/Vision/ImageSource.php
@@ -2,17 +2,20 @@
 
 namespace LLPhant\Chat\Vision;
 
+use GuzzleHttp\Client;
 use JsonSerializable;
 
 class ImageSource implements JsonSerializable
 {
     private readonly string $url;
+    private ?string $base64 = null;
 
     public function __construct(string $urlOrBase64Image, private readonly ImageQuality $detail = ImageQuality::Auto)
     {
         if ($this->isUrl($urlOrBase64Image)) {
             $this->url = $urlOrBase64Image;
         } elseif ($this->isBase64($urlOrBase64Image)) {
+            $this->base64 = $urlOrBase64Image;
             $this->url = 'data:image/jpeg;base64,'.$urlOrBase64Image;
         } else {
             throw new \InvalidArgumentException('Invalid image URL or base64 format.');
@@ -27,6 +30,17 @@ class ImageSource implements JsonSerializable
     protected function isBase64(string $image): bool
     {
         return \preg_match('/^[a-zA-Z0-9\/\r\n+]*={0,2}$/', $image) === 1;
+    }
+
+    public function getBase64(Client $client): string
+    {
+        if (is_null($this->base64)) {
+            $response = $client->request('GET', $this->url);
+            $imageData = (string)$response->getBody();
+            $this->base64 = base64_encode($imageData);
+        }
+
+        return $this->base64;
     }
 
     /**

--- a/src/Chat/Vision/ImageSource.php
+++ b/src/Chat/Vision/ImageSource.php
@@ -8,6 +8,7 @@ use JsonSerializable;
 class ImageSource implements JsonSerializable
 {
     private readonly string $url;
+
     private ?string $base64 = null;
 
     public function __construct(string $urlOrBase64Image, private readonly ImageQuality $detail = ImageQuality::Auto)
@@ -36,7 +37,7 @@ class ImageSource implements JsonSerializable
     {
         if (is_null($this->base64)) {
             $response = $client->request('GET', $this->url);
-            $imageData = (string)$response->getBody();
+            $imageData = (string) $response->getBody();
             $this->base64 = base64_encode($imageData);
         }
 


### PR DESCRIPTION
Inspired by https://github.com/theodo-group/LLPhant/pull/252 I wanted to port it to Ollama.

Since [Ollama wants the images in base64](https://github.com/ollama/ollama/blob/main/docs/api.md#request-with-images) (URLs not supported) I thought about adding a base64 conversion method directly to the `ImageSource` class.

Let me know what you think.

At the moment I use this script for testing:

```php
<?php

require 'vendor/autoload.php';

$config = new \LLPhant\OllamaConfig();
$config->model = 'llama3.2-vision';
$chat = new \LLPhant\Chat\OllamaChat($config);

$messages = [
    \LLPhant\Chat\Vision\VisionMessage::fromImages([
        new \LLPhant\Chat\Vision\ImageSource('https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Pilot_Urban_MR_Retro_Pop_M_Fountain_Pen_%28no_clip%29.jpg/1280px-Pilot_Urban_MR_Retro_Pop_M_Fountain_Pen_%28no_clip%29.jpg')
    ], 'Describe this image')
];
$response = $chat->generateChat($messages);
echo $response;
```

Since tests with Ollama are mocked, does it make sense to implement a test for this? From what I've seen the responses are not really predictable.