### PR TITLE
OpenAIChat: added functionsCalled and returned value from functions

### DIFF
--- a/src/Chat/CalledFunction/CalledFunction.php
+++ b/src/Chat/CalledFunction/CalledFunction.php
@@ -9,7 +9,7 @@ class CalledFunction
     /**
      * @param  array<string, mixed>  $arguments
      */
-    public function __construct(public FunctionInfo $definition, public array $arguments, public string $return)
+    public function __construct(public FunctionInfo $definition, public array $arguments, public string $return, public ?string $tool_call_id = null)
     {
     }
 }

--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -84,15 +84,9 @@ class OpenAIChat implements ChatInterface
 
     public function generateTextOrReturnFunctionCalled(string $prompt): string|FunctionInfo
     {
-        $this->functionsCalled = [];
         $answer = $this->generate($prompt);
 
-        $toolsToCall = $this->getToolsToCall($answer);
-
-        foreach ($toolsToCall as $toolToCall) {
-            $this->functionsCalled[] = $toolToCall;
-        }
-
+        $this->functionsCalled = $this->getToolsToCall($answer);
         if ($this->functionsCalled) {
             $lastKey = array_key_last($this->functionsCalled);
 
@@ -125,13 +119,7 @@ class OpenAIChat implements ChatInterface
     {
         $answer = $this->generateResponseFromMessages($messages);
 
-        $toolsToCall = $this->getToolsToCall($answer);
-
-        $this->functionsCalled = [];
-        foreach ($toolsToCall as $toolToCall) {
-            $this->functionsCalled[] = $toolToCall;
-        }
-
+        $this->functionsCalled = $this->getToolsToCall($answer);
         if ($this->functionsCalled) {
             $lastKey = array_key_last($this->functionsCalled);
 

--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -84,9 +84,15 @@ class OpenAIChat implements ChatInterface
 
     public function generateTextOrReturnFunctionCalled(string $prompt): string|FunctionInfo
     {
+        $this->functionsCalled = [];
         $answer = $this->generate($prompt);
 
-        $this->functionsCalled = $this->getToolsToCall($answer);
+        $toolsToCall = $this->getToolsToCall($answer);
+
+        foreach ($toolsToCall as $toolToCall) {
+            $this->functionsCalled[] = $toolToCall;
+        }
+
         if ($this->functionsCalled) {
             $lastKey = array_key_last($this->functionsCalled);
 
@@ -119,7 +125,13 @@ class OpenAIChat implements ChatInterface
     {
         $answer = $this->generateResponseFromMessages($messages);
 
-        $this->functionsCalled = $this->getToolsToCall($answer);
+        $toolsToCall = $this->getToolsToCall($answer);
+
+        $this->functionsCalled = [];
+        foreach ($toolsToCall as $toolToCall) {
+            $this->functionsCalled[] = $toolToCall;
+        }
+
         if ($this->functionsCalled) {
             $lastKey = array_key_last($this->functionsCalled);
 

--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -39,6 +39,8 @@ class OpenAIChat implements ChatInterface
     /** @var FunctionInfo[] */
     private array $tools = [];
 
+    public ?FunctionInfo $lastFunctionCalled = null;
+
     /** @var CalledFunction[] */
     public array $functionsCalled = [];
 
@@ -86,6 +88,8 @@ class OpenAIChat implements ChatInterface
     public function generateTextOrReturnFunctionCalled(string $prompt): string|FunctionInfo
     {
         $this->functionsCalled = [];
+        $this->lastFunctionCalled = null;
+
         $answer = $this->generate($prompt);
         $this->handleTools($answer);
 
@@ -330,6 +334,7 @@ class OpenAIChat implements ChatInterface
         $functionToCall = $this->getFunctionInfoFromName($functionName, $toolCallId);
         $return = $functionToCall->instance->{$functionToCall->name}(...$arguments);
         $this->functionsCalled[] = new CalledFunction($functionToCall, $arguments, $return, $toolCallId);
+        $this->lastFunctionCalled = $functionToCall;
     }
 
     /**


### PR DESCRIPTION
This PR aims to bring feature parity between OllamaChat and OpenAIChat.

I think, as a multi provider framework, llphant should work the same across platforms, as much as possible.

In OllamaChat we added functionsCalled array because it's possible to have more than one funcion called, and the return value of the function is also available.

This PR brings these features to OpenAIChat too.

**EDIT**: while developing this PR I noticed that `generateChat()` wasn't working properly when tools were called, in fact after the tools are called, the LLM needs to be called again in order to process the output of the tool and answer user's question. This is what OllamaChat does since long time, so I ported it here too (it wasn't easy).

**WARNING**: in OllamaChat we removed lastFunctionCalled, which is removed from OpenAIChat now too for parity but.. is it considered a breaking change? how do you want to handle with these situations?