### PR TITLE
Changing the return type from `array` to `iterable` in the method sig…

### DIFF
--- a/src/Embeddings/VectorStores/VectorStoreBase.php
+++ b/src/Embeddings/VectorStores/VectorStoreBase.php
@@ -25,5 +25,5 @@ abstract class VectorStoreBase
      * @param  array<string, string|int>|array<mixed[]>  $additionalArguments
      * @return Document[]
      */
-    abstract public function similaritySearch(array $embedding, int $k = 4, array $additionalArguments = []): array;
+    abstract public function similaritySearch(array $embedding, int $k = 4, array $additionalArguments = []): iterable;
 }


### PR DESCRIPTION

1. **Flexibility**: The `iterable` type hint allows the method to return any kind of iterable data structure, such as arrays, generators, or objects implementing the `\Traversable` interface.

2. **Performance**: Using generators can enhance performance and reduce memory usage, especially with large datasets.