### PR TITLE
Add Sonnet 3.5 20241022 to AnthropicConfig

### DIFF
--- a/src/AnthropicConfig.php
+++ b/src/AnthropicConfig.php
@@ -12,6 +12,8 @@ class AnthropicConfig
 
     final public const CLAUDE_3_5_SONNET = 'claude-3-5-sonnet-20240620';
 
+    final public const CLAUDE_3_5_SONNET_20241022 = 'claude-3-5-sonnet-20241022';
+
     final public const CLAUDE_3_SONNET = 'claude-3-sonnet-20240229';
 
     final public const CLAUDE_3_OPUS = 'claude-3-opus-20240229';


### PR DESCRIPTION
This is a small change, but would be good to start a discussion on the default model. 

As Sonnet 3.5 in both versions is priced at the same level, maybe the default should be the newer one? After my change, the older one is available under the `CLAUDE_3_5_SONNET` const, and a user has to explicitly select the `20241022` version by using `CLAUDE_3_5_SONNET_20241022`. 

An alternative would be to use `20241022` when `CLAUDE_3_5_SONNET` is selected. The Claude UI has only `20241022` available, so I do not expect this to be a BC break in LLPhant? 