### PR TITLE
Add phpword 1.4 for security reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ First, install LLPhant via the [Composer](https://getcomposer.org/) package mana
 composer require theodo-group/llphant
 ```
 
+In case you have not installed the GD extension, and you do not want to add it to your PHP setup, 
+you can use the `--ignore-platform-req=ext-gd` option
+
+```bash
+composer require theodo-group/llphant --ignore-platform-req=ext-gd
+```
+
 If you want to try the latest features of this library, you can use:
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "guzzlehttp/guzzle": "^7.4.5",
         "guzzlehttp/psr7": "^2.7",
         "openai-php/client": "^v0.13.0",
-        "phpoffice/phpword": "^1.3.0",
+        "phpoffice/phpword": "^1.4.0",
         "psr/http-message": "^2.0",
         "psr/log": "^3.0",
         "smalot/pdfparser": "^2.11"

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,4 +5,4 @@ In this directory you can find a complete environment for running integration te
 First `cp .env.dist .env`.
 Review options and `docker-compose up -d`.
 
-Inside the docker run `composer install`
+Inside the docker run `composer install --ignore-platform-req=ext-gd`


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-42hm-pq2f-3r7m
Please note that, in order to not be forced to load the unused GD extension, you could use the `--ignore-platform-req=ext-gd` option
For example:
```bash
composer require theodo-group/llphant --ignore-platform-req=ext-gd
```
