### PR TITLE
fix: serialize empty tool properties as {} instead of []

### DIFF
--- a/src/Chat/Anthropic/AnthropicMessage.php
+++ b/src/Chat/Anthropic/AnthropicMessage.php
@@ -40,6 +40,16 @@ class AnthropicMessage extends Message implements \JsonSerializable
         $message = new self();
         $message->role = ChatRole::Assistant;
 
+        // A tool_use block for a parameterless tool decodes its `input: {}` as an empty
+        // PHP array, which would re-serialise as `[]` and be rejected by Anthropic
+        // (400 "tool_use.input: Input should be an object"). Coerce it back to an object.
+        foreach ($responses as &$response) {
+            if (($response['type'] ?? null) === 'tool_use' && ($response['input'] ?? null) === []) {
+                $response['input'] = new stdClass();
+            }
+        }
+        unset($response);
+
         $message->contentsArray = $responses;
 
         return $message;
@@ -50,17 +60,9 @@ class AnthropicMessage extends Message implements \JsonSerializable
      */
     public function jsonSerialize(): array
     {
-        $contents = $this->contentsArray;
-        foreach ($contents as &$item) {
-            if (($item['type'] ?? null) === 'tool_use' && ($item['input'] ?? null) === []) {
-                $item['input'] = new stdClass();
-            }
-        }
-        unset($item);
-
         return [
             'role' => $this->role->value,
-            'content' => $contents,
+            'content' => $this->contentsArray,
         ];
     }
 }

--- a/src/Chat/Anthropic/AnthropicMessage.php
+++ b/src/Chat/Anthropic/AnthropicMessage.php
@@ -4,6 +4,7 @@ namespace LLPhant\Chat\Anthropic;
 
 use LLPhant\Chat\Enums\ChatRole;
 use LLPhant\Chat\Message;
+use stdClass;
 
 class AnthropicMessage extends Message implements \JsonSerializable
 {
@@ -49,9 +50,17 @@ class AnthropicMessage extends Message implements \JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $contents = $this->contentsArray;
+        foreach ($contents as &$item) {
+            if (($item['type'] ?? null) === 'tool_use' && ($item['input'] ?? null) === []) {
+                $item['input'] = new stdClass();
+            }
+        }
+        unset($item);
+
         return [
             'role' => $this->role->value,
-            'content' => $this->contentsArray,
+            'content' => $contents,
         ];
     }
 }

--- a/src/Chat/FunctionInfo/FunctionFormatter.php
+++ b/src/Chat/FunctionInfo/FunctionFormatter.php
@@ -2,6 +2,8 @@
 
 namespace LLPhant\Chat\FunctionInfo;
 
+use stdClass;
+
 class FunctionFormatter
 {
     /**
@@ -29,7 +31,7 @@ class FunctionFormatter
      * @deprecated Switch to using tools instead of functions in your code when using OpenAIChat
      * This is pretty fine instead when using AnthropicChat
      *
-     * @return array{name: string, description: string, parameters: array{type: string, properties: array<string, mixed[]>, required: string[]}}
+     * @return array{name: string, description: string, parameters: array{type: string, properties: array<string, mixed[]>|stdClass, required: string[]}}
      */
     public static function formatOneFunctionToOpenAI(FunctionInfo $functionInfo): array
     {
@@ -49,7 +51,7 @@ class FunctionFormatter
             'description' => $functionInfo->description,
             'parameters' => [
                 'type' => 'object',
-                'properties' => $parametersOpenAI,
+                'properties' => $parametersOpenAI === [] ? new stdClass() : $parametersOpenAI,
                 'required' => $requiredParametersOpenAI,
             ],
         ];
@@ -154,7 +156,7 @@ class FunctionFormatter
     /**
      * @param  Parameter[]  $parameters
      * @param  Parameter[]  $requiredParameters
-     * @return array{type: string, properties: array<string, array{type: string, description: string}>}
+     * @return array{type: string, properties: array<string, array{type: string, description: string}>|stdClass}
      */
     private static function toInputSchema(array $parameters, array $requiredParameters): array
     {
@@ -177,7 +179,7 @@ class FunctionFormatter
 
         return [
             'type' => 'object',
-            'properties' => $result,
+            'properties' => $result === [] ? new stdClass() : $result,
             'required' => $requiredParametersNames,
         ];
     }

--- a/tests/Unit/Chat/Anthropic/AnthropicMessageTest.php
+++ b/tests/Unit/Chat/Anthropic/AnthropicMessageTest.php
@@ -6,6 +6,7 @@ use LLPhant\Chat\Anthropic\AnthropicImage;
 use LLPhant\Chat\Anthropic\AnthropicImageType;
 use LLPhant\Chat\Anthropic\AnthropicMessage;
 use LLPhant\Chat\Anthropic\AnthropicVisionMessage;
+use stdClass;
 
 it('generates a correct tool result message for Anthropic', function () {
 
@@ -61,13 +62,14 @@ it('generates a correct assistant answer message for Anthropic', function () {
 // Without the fix, a parameterless tool call decodes `input: {}` as an empty PHP array,
 // which re-serializes as `[]` instead of `{}`. Anthropic rejects it with 400
 // "tool_use.input: Input should be an object".
+// The coercion must be in fromAssistantAnswer() because getContentFrom() reads
+// contentsArray directly without going through jsonSerialize().
 it('serializes an empty tool_use input as an object for Anthropic', function () {
-    $assistantAnswer = [
-        ['type' => 'tool_use', 'id' => 'toolu_01A09q90qw90lq917835lq9', 'name' => 'list_products', 'input' => []],
-    ];
+    $message = AnthropicMessage::fromAssistantAnswer([
+        ['type' => 'tool_use', 'id' => 'toolu_x', 'name' => 'list_products', 'input' => []],
+    ]);
 
-    expect(\json_encode(AnthropicMessage::fromAssistantAnswer($assistantAnswer)))
-        ->toContain('"input":{}');
+    expect($message->contentsArray[0]['input'])->toBeInstanceOf(stdClass::class);
 });
 
 it('generates a correct vison message for Anthropic', function () {

--- a/tests/Unit/Chat/Anthropic/AnthropicMessageTest.php
+++ b/tests/Unit/Chat/Anthropic/AnthropicMessageTest.php
@@ -58,6 +58,18 @@ it('generates a correct assistant answer message for Anthropic', function () {
     expect(\json_encode(AnthropicMessage::fromAssistantAnswer($assistantAnswer), JSON_PRETTY_PRINT))->toBe($expectedJson);
 });
 
+// Without the fix, a parameterless tool call decodes `input: {}` as an empty PHP array,
+// which re-serializes as `[]` instead of `{}`. Anthropic rejects it with 400
+// "tool_use.input: Input should be an object".
+it('serializes an empty tool_use input as an object for Anthropic', function () {
+    $assistantAnswer = [
+        ['type' => 'tool_use', 'id' => 'toolu_01A09q90qw90lq917835lq9', 'name' => 'list_products', 'input' => []],
+    ];
+
+    expect(\json_encode(AnthropicMessage::fromAssistantAnswer($assistantAnswer)))
+        ->toContain('"input":{}');
+});
+
 it('generates a correct vison message for Anthropic', function () {
 
     $expectedJson = <<<'JSON'

--- a/tests/Unit/Chat/Function/FunctionFormatterTest.php
+++ b/tests/Unit/Chat/Function/FunctionFormatterTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Chat\Function;
 use LLPhant\Chat\FunctionInfo\FunctionFormatter;
 use LLPhant\Chat\FunctionInfo\FunctionInfo;
 use LLPhant\Chat\FunctionInfo\Parameter;
+use stdClass;
 use Tests\Integration\Chat\MailerExample;
 
 it('can format function info with basic types to OpenAI format', function () {
@@ -160,6 +161,20 @@ it('can format function info with array of objects types to OpenAI format', func
     ];
 
     expect(FunctionFormatter::formatOneFunctionToOpenAI($functionInfo))->toBe($expected);
+});
+
+// Without the fix, empty parameters serialize properties as [] (JSON array) instead of {} (JSON object).
+// Anthropic rejects this with: 400 invalid_request_error:
+// tools.N.custom.input_schema.properties: Input should be an object
+it('serializes empty tool properties as an object not an array', function () {
+    $function = new FunctionInfo('no_args_tool', new stdClass(), 'A tool with no parameters', [], []);
+
+    $anthropic = FunctionFormatter::formatFunctionsToAnthropic([$function]);
+    $openai = FunctionFormatter::formatFunctionsToOpenAI([$function]);
+
+    expect($anthropic[0]['input_schema']['properties'])->toEqual(new stdClass());
+    expect($openai[0]['parameters']['properties'])->toEqual(new stdClass());
+    expect(json_encode($anthropic[0]))->toContain('"properties":{}');
 });
 
 it('can format function info for Anthropic', function () {


### PR DESCRIPTION
## Problem

Two related serialization bugs affect parameterless tools:

**1. Tool schema (`FunctionFormatter`)**
When a tool has no parameters, `properties` is an empty PHP array. `json_encode([])` produces `[]` instead of `{}`. Anthropic rejects this with:
```
400 invalid_request_error: tools.N.custom.input_schema.properties: Input should be an object
```

**2. Tool call round-trip (`AnthropicMessage`)**
When Anthropic returns a `tool_use` block for a parameterless tool, `input: {}` is decoded by PHP as an empty array, which re-serializes as `[]`. Anthropic rejects this with:
```
400 invalid_request_error: tool_use.input: Input should be an object
```

## Fix

**`FunctionFormatter`** — cast the empty case to `stdClass` in both `formatOneFunctionToOpenAI()` (OpenAI formatter) and `toInputSchema()` (Anthropic formatter):
```php
'properties' => $result === [] ? new stdClass() : $result,
```

**`AnthropicMessage`** — coerce empty `input` arrays to `stdClass` in `fromAssistantAnswer()`, where `contentsArray` is populated. The fix must live here because `getContentFrom()` reads `contentsArray` directly when building the request payload, bypassing `jsonSerialize()`:
```php
foreach ($responses as &$response) {
    if (($response['type'] ?? null) === 'tool_use' && ($response['input'] ?? null) === []) {
        $response['input'] = new stdClass();
    }
}
unset($response);
```

## Tests

- `FunctionFormatterTest`: asserts `properties` serializes as `{}` for both Anthropic and OpenAI formatters
- `AnthropicMessageTest`: asserts `contentsArray[0]['input']` is a `stdClass` after `fromAssistantAnswer()`, which is the path used by `getContentFrom()` when building the request payload