### PR TITLE
feat(atlascloud): use configurable validated default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@ It is compatible with Symfony and Laravel.
 We are working to expand the support of different LLMs. Right now, we are supporting [OpenAI](https://openai.com/blog/openai-api), [Anthropic](https://www.anthropic.com/), [Mistral](https://mistral.ai/), [Ollama](https://ollama.ai/), [LM Studio](https://lmstudio.ai/), [Atlas Cloud](https://www.atlascloud.ai/docs) and services compatible with the OpenAI API such as [LocalAI](https://localai.io/).
 Ollama that can be used to run LLM locally such as [Llama 2](https://llama.meta.com/).
 
+## Atlas Cloud
+
+LLPhant's `AtlasCloudConfig` targets the OpenAI-compatible Atlas Cloud endpoint
+at `https://api.atlascloud.ai/v1` and now defaults to the validated chat model
+`qwen/qwen3.5-flash`.
+
+The configuration also accepts any Atlas model slug exposed by your account via
+the optional `ATLASCLOUD_MODEL` environment variable. Examples from the current
+public Text model list include:
+
+- `qwen/qwen3.5-flash`
+- `qwen/qwen3.6-plus`
+- `deepseek-ai/deepseek-v4-flash`
+- `deepseek-ai/deepseek-v4-pro`
+- `google/gemini-3.5-flash`
+- `zai-org/glm-4.7`
+
 We want to thank few amazing projects that we use here or inspired us:
 
 -   the learnings from using [LangChain](https://www.langchain.com/) and [LLamaIndex](https://www.llamaindex.ai/)

--- a/docker/.env.dist
+++ b/docker/.env.dist
@@ -4,6 +4,7 @@ PHP_VERSION=8.2
 ELASTIC_URL=http://elasticsearch:9200
 OPENAI_API_KEY=
 ATLASCLOUD_API_KEY=
+ATLASCLOUD_MODEL=qwen/qwen3.5-flash
 GEMINI_API_KEY=
 # Run docker compose  -f devx/docker-compose-milvus.yml up -d
 MILVUS_HOST=host.docker.internal

--- a/src/AtlasCloudConfig.php
+++ b/src/AtlasCloudConfig.php
@@ -28,7 +28,7 @@ class AtlasCloudConfig extends OpenAIConfig
         parent::__construct(
             apiKey: $apiKey ?? Utility::readEnvironment('ATLASCLOUD_API_KEY'),
             url: $url,
-            model: $model ?? 'owl',
+            model: $model ?? Utility::readEnvironment('ATLASCLOUD_MODEL', 'qwen/qwen3.5-flash'),
             client: $client,
             modelOptions: $modelOptions,
         );

--- a/tests/Unit/Chat/AtlasCloudConfigTest.php
+++ b/tests/Unit/Chat/AtlasCloudConfigTest.php
@@ -8,7 +8,13 @@ use LLPhant\AtlasCloudConfig;
 
 afterEach(function () {
     putenv('ATLASCLOUD_API_KEY');
-    unset($_ENV['ATLASCLOUD_API_KEY'], $_SERVER['ATLASCLOUD_API_KEY']);
+    putenv('ATLASCLOUD_MODEL');
+    unset(
+        $_ENV['ATLASCLOUD_API_KEY'],
+        $_ENV['ATLASCLOUD_MODEL'],
+        $_SERVER['ATLASCLOUD_API_KEY'],
+        $_SERVER['ATLASCLOUD_MODEL']
+    );
 });
 
 it('uses atlas cloud defaults', function () {
@@ -16,7 +22,7 @@ it('uses atlas cloud defaults', function () {
 
     expect($config->apiKey)->toBe('test-key')
         ->and($config->url)->toBe('https://api.atlascloud.ai/v1')
-        ->and($config->model)->toBe('owl');
+        ->and($config->model)->toBe('qwen/qwen3.5-flash');
 });
 
 it('reads api key from environment', function () {
@@ -25,6 +31,14 @@ it('reads api key from environment', function () {
     $config = new AtlasCloudConfig();
 
     expect($config->apiKey)->toBe('env-key');
+});
+
+it('reads model from environment', function () {
+    putenv('ATLASCLOUD_MODEL=deepseek-ai/deepseek-v4-flash');
+
+    $config = new AtlasCloudConfig('test-key');
+
+    expect($config->model)->toBe('deepseek-ai/deepseek-v4-flash');
 });
 
 it('allows overriding url, model and model options', function () {

--- a/tests/Unit/Chat/AtlasCloudConfigTest.php
+++ b/tests/Unit/Chat/AtlasCloudConfigTest.php
@@ -41,6 +41,13 @@ it('reads model from environment', function () {
     expect($config->model)->toBe('deepseek-ai/deepseek-v4-flash');
 });
 
+it('falls back to the default model when ATLASCLOUD_MODEL is set but empty', function () {
+    putenv('ATLASCLOUD_MODEL=');
+
+    $config = new AtlasCloudConfig('test-key');
+
+    expect($config->model)->toBe('qwen/qwen3.5-flash');
+});
 it('allows overriding url, model and model options', function () {
     $config = new AtlasCloudConfig(
         apiKey: 'test-key',


### PR DESCRIPTION
## Summary
- update AtlasCloudConfig to default to a currently available Atlas Cloud Text model
- allow overriding the Atlas model via ATLASCLOUD_MODEL
- document the Atlas Cloud default and a small set of live-verified Text model examples

## Validation
- fetched https://api.atlascloud.ai/api/v1/models and confirmed the listed Text models have display_console=true
- git diff --check
- not run: Pest/PHP tests locally because this machine has no php/composer, and Docker daemon is not running

No sponsor, logo, partner, or credits copy was added.